### PR TITLE
Add serializer helper to describe-model

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
  * [Contributing](#Contributing)
 
 ## Installation
+
 ```
 ember install ember-test-utils
 ```
@@ -116,7 +117,7 @@ describeComponent(...unit('my-greeting', ['component:foo', 'helper:bar']), funct
 ```
 
 ## `describeModel`
-A single `model` shortcut is provided to allow you to turn this:
+Two shortcuts are provided (`model` and `serializer`) to allow you to turn this:
 
 ```js
 import {expect} from 'chai'
@@ -151,6 +152,18 @@ describeModel(...model('person', ['model:company']), function () {
     expect(model).not.to.equal(undefined)
   })
 })
+```
+
+The only difference between `model` and `serializer` is what the description of the test will end up being:
+
+```
+Unit | Model | model-name
+```
+
+vs.
+
+```
+Unit | Serializer | model-name
 ```
 
 ## `describeModule`

--- a/test-support/helpers/ember-test-utils/describe-model.js
+++ b/test-support/helpers/ember-test-utils/describe-model.js
@@ -21,3 +21,23 @@ export function model (name, dependencies, options = {}) {
     options
   ]
 }
+
+/**
+ * Generate an Array of the first 3 params to describeModel, so that we can keep the function definition on the
+ * same line as the describeModel call itself
+ * @param {String} name - the name of the model being tested
+ * @param {String[]} dependencies - the entries for the 'needs' property in the options for describeModel
+ * @param {Object} options - any additional options needed for describeModel
+ * @returns {Array} the first three params to describeModel
+ */
+export function serializer (name, dependencies, options = {}) {
+  if (dependencies) {
+    options.needs = dependencies
+  }
+
+  return [
+    name,
+    'Unit | Serializer | ${name}',
+    options
+  ]
+}


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [ ] #patch# - backwards-compatible bug fix
- [x] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
-  **Added** a `serializer` shortcut to the `describe-model` module which yields a `Unit | Serializer | model-name` description compared to the `Unit | Model | model-name` that the `model` shortcut yields. 
