### PR TITLE
Fix description

### DIFF
--- a/test-support/helpers/ember-test-utils/describe-component.js
+++ b/test-support/helpers/ember-test-utils/describe-component.js
@@ -2,7 +2,6 @@
  * Shortcuts for generating the params passed to describeComponent from ember-mocha
  */
 
-import Ember from 'ember'
 import _ from 'lodash'
 
 /**
@@ -11,17 +10,17 @@ import _ from 'lodash'
  * @param {Object} options - any additional options to set
  * @returns {Object[]} an array of items that need to be passed in to describeComponent
  */
-function testCtx (name, options = {}) {
+function component (name, options = {}) {
   const testType = (options.unit) ? 'Unit' : 'Integration'
   return [
     name,
-    `${testType}: ${Ember.String.classify(name)}Component`,
+    `${testType} | Component | ${name}`,
     options
   ]
 }
 
 /**
- * A shortcut for filling in the text context in a describeComponent
+ * A shortcut for filling in the first three params for describeComponent unit test
  * @param {String} name - the name of the component
  * @param {String[]} dependencies - the list of "needs" for this component
  * @param {Object} options - any additional options to set (alongside unit: true)
@@ -31,15 +30,15 @@ export function unit (name, dependencies, options = {}) {
   if (dependencies) {
     options.needs = dependencies
   }
-  return testCtx(name, _.assign(options, {unit: true}))
+  return component(name, _.assign(options, {unit: true}))
 }
 
 /**
- * A shortcut for filling in the text context in a describeComponent
+ * A shortcut for filling in the first three params for describeComponent integration test
  * @param {String} name - the name of the component
  * @param {Object} options - any additional options to set (alongside integration: true)
  * @returns {Object[]} an array of items that need to be passed in to describeComponent
  */
 export function integration (name, options = {}) {
-  return testCtx(name, _.assign(options, {integration: true}))
+  return component(name, _.assign(options, {integration: true}))
 }

--- a/test-support/helpers/ember-test-utils/describe-model.js
+++ b/test-support/helpers/ember-test-utils/describe-model.js
@@ -17,7 +17,7 @@ export function model (name, dependencies, options = {}) {
 
   return [
     name,
-    'Unit | Model | ${name}',
+    `Unit | Model | ${name}`,
     options
   ]
 }
@@ -37,7 +37,7 @@ export function serializer (name, dependencies, options = {}) {
 
   return [
     name,
-    'Unit | Serializer | ${name}',
+    `Unit | Serializer | ${name}`,
     options
   ]
 }

--- a/test-support/helpers/ember-test-utils/describe-module.js
+++ b/test-support/helpers/ember-test-utils/describe-module.js
@@ -20,7 +20,7 @@ export function module (type, name, dependencies, options = {}) {
 
   return [
     `${type}:${name}`,
-    Ember.String.classify(name + ' ' + type),
+    `Unit | ${Ember.String.classify(type)} | ${name}`,
     options
   ]
 }

--- a/tests/unit/describe-component-test.js
+++ b/tests/unit/describe-component-test.js
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for the describe-model module
+ */
+import {expect} from 'chai'
+import {beforeEach, describe, it} from 'mocha'
+import {unit, integration} from 'dummy/tests/helpers/ember-test-utils/describe-component'
+
+describe('describeComponent()', function () {
+  describe('unit()', function () {
+    let args
+    describe('when just name is given', function () {
+      beforeEach(function () {
+        args = unit('my-component')
+      })
+
+      it('should give proper component name', function () {
+        expect(args[0]).to.equal('my-component')
+      })
+
+      it('should give proper test description', function () {
+        expect(args[1]).to.equal('Unit | Component | my-component')
+      })
+
+      it('should set unit to true in options', function () {
+        expect(args[2]).to.eql({unit: true})
+      })
+    })
+
+    describe('when dependencies are given', function () {
+      beforeEach(function () {
+        args = unit('my-component', ['component:foo-bar', 'helper:baz'])
+      })
+
+      it('should set needs to dependencies in options', function () {
+        expect(args[2].needs).to.eql(['component:foo-bar', 'helper:baz'])
+      })
+    })
+  })
+
+  describe('integration()', function () {
+    let args
+    beforeEach(function () {
+      args = integration('my-component')
+    })
+
+    it('should give proper component name', function () {
+      expect(args[0]).to.equal('my-component')
+    })
+
+    it('should give proper test description', function () {
+      expect(args[1]).to.equal('Integration | Component | my-component')
+    })
+
+    it('should set integration to true in options', function () {
+      expect(args[2]).to.eql({integration: true})
+    })
+  })
+})

--- a/tests/unit/describe-model-test.js
+++ b/tests/unit/describe-model-test.js
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for the describe-model module
+ */
+import {expect} from 'chai'
+import {beforeEach, describe, it} from 'mocha'
+import {model, serializer} from 'dummy/tests/helpers/ember-test-utils/describe-model'
+
+describe('describeModel()', function () {
+  describe('model()', function () {
+    let args
+    describe('when just name is given', function () {
+      beforeEach(function () {
+        args = model('person')
+      })
+
+      it('should give proper model name', function () {
+        expect(args[0]).to.equal('person')
+      })
+
+      it('should give proper test description', function () {
+        expect(args[1]).to.equal('Unit | Model | person')
+      })
+
+      it('should give blank options', function () {
+        expect(args[2]).to.eql({})
+      })
+    })
+
+    describe('when dependencies are given', function () {
+      beforeEach(function () {
+        args = model('person', ['model:company'])
+      })
+
+      it('should set needs to dependencies in options', function () {
+        expect(args[2].needs).to.eql(['model:company'])
+      })
+    })
+  })
+
+  describe('serializer()', function () {
+    let args
+    describe('when just name is given', function () {
+      beforeEach(function () {
+        args = serializer('company')
+      })
+
+      it('should give proper model name', function () {
+        expect(args[0]).to.equal('company')
+      })
+
+      it('should give proper test description', function () {
+        expect(args[1]).to.equal('Unit | Serializer | company')
+      })
+
+      it('should give blank options', function () {
+        expect(args[2]).to.eql({})
+      })
+    })
+
+    describe('when dependencies are given', function () {
+      beforeEach(function () {
+        args = serializer('company', ['adapter:application', 'serializer:company'])
+      })
+
+      it('should set needs to dependencies in options', function () {
+        expect(args[2].needs).to.eql(['adapter:application', 'serializer:company'])
+      })
+    })
+  })
+})

--- a/tests/unit/describe-module-test.js
+++ b/tests/unit/describe-module-test.js
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for the describe-model module
+ */
+import {expect} from 'chai'
+import {beforeEach, describe, it} from 'mocha'
+import {route, controller} from 'dummy/tests/helpers/ember-test-utils/describe-module'
+
+describe('describeModule()', function () {
+  describe('route()', function () {
+    let args
+    describe('when just name is given', function () {
+      beforeEach(function () {
+        args = route('thing')
+      })
+
+      it('should give proper route name', function () {
+        expect(args[0]).to.equal('route:thing')
+      })
+
+      it('should give proper test description', function () {
+        expect(args[1]).to.equal('Unit | Route | thing')
+      })
+
+      it('should give blank options', function () {
+        expect(args[2]).to.eql({})
+      })
+    })
+
+    describe('when dependencies are given', function () {
+      beforeEach(function () {
+        args = route('thing', ['model:thing'])
+      })
+
+      it('should set needs to dependencies in options', function () {
+        expect(args[2].needs).to.eql(['model:thing'])
+      })
+    })
+  })
+
+  describe('controller()', function () {
+    let args
+    describe('when just name is given', function () {
+      beforeEach(function () {
+        args = controller('thing')
+      })
+
+      it('should give proper route name', function () {
+        expect(args[0]).to.equal('controller:thing')
+      })
+
+      it('should give proper test description', function () {
+        expect(args[1]).to.equal('Unit | Controller | thing')
+      })
+
+      it('should give blank options', function () {
+        expect(args[2]).to.eql({})
+      })
+    })
+
+    describe('when dependencies are given', function () {
+      beforeEach(function () {
+        args = controller('thing', ['model:thing'])
+      })
+
+      it('should set needs to dependencies in options', function () {
+        expect(args[2].needs).to.eql(['model:thing'])
+      })
+    })
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
# CHANGELOG
- **Fixed** test descriptions to be consistent in the format of `Unit | Component | my-component` instead of `Unit: MyComponentComponent` so that `grep`-ing for your component name will actually find tests for your component now. 
  - **Added** unit tests for the helpers themselves to make sure descriptions remain correct.
