### PR TITLE
Use '/' as test heading separator rather than '|'

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ import {describeModel, it} from 'ember-mocha'
 
 describeModel(
   'person',
-  'Unit | Model | person',
+  'Unit / Model / person',
   {
     // Specify the other units that are required for this test.
     needs: ['model:company']
@@ -157,13 +157,13 @@ describeModel(...model('person', ['model:company']), function () {
 The only difference between `model` and `serializer` is what the description of the test will end up being:
 
 ```
-Unit | Model | model-name
+Unit / Model / model-name
 ```
 
 vs.
 
 ```
-Unit | Serializer | model-name
+Unit / Serializer / model-name
 ```
 
 ## `describeModule`

--- a/test-support/helpers/ember-test-utils/describe-component.js
+++ b/test-support/helpers/ember-test-utils/describe-component.js
@@ -14,7 +14,7 @@ function component (name, options = {}) {
   const testType = (options.unit) ? 'Unit' : 'Integration'
   return [
     name,
-    `${testType} | Component | ${name}`,
+    `${testType} / Component / ${name}`,
     options
   ]
 }

--- a/test-support/helpers/ember-test-utils/describe-model.js
+++ b/test-support/helpers/ember-test-utils/describe-model.js
@@ -17,7 +17,7 @@ export function model (name, dependencies, options = {}) {
 
   return [
     name,
-    `Unit | Model | ${name}`,
+    `Unit / Model / ${name}`,
     options
   ]
 }
@@ -37,7 +37,7 @@ export function serializer (name, dependencies, options = {}) {
 
   return [
     name,
-    `Unit | Serializer | ${name}`,
+    `Unit / Serializer / ${name}`,
     options
   ]
 }

--- a/test-support/helpers/ember-test-utils/describe-module.js
+++ b/test-support/helpers/ember-test-utils/describe-module.js
@@ -20,7 +20,7 @@ export function module (type, name, dependencies, options = {}) {
 
   return [
     `${type}:${name}`,
-    `Unit | ${Ember.String.classify(type)} | ${name}`,
+    `Unit / ${Ember.String.classify(type)} / ${name}`,
     options
   ]
 }

--- a/tests/unit/describe-component-test.js
+++ b/tests/unit/describe-component-test.js
@@ -18,7 +18,7 @@ describe('describeComponent()', function () {
       })
 
       it('should give proper test description', function () {
-        expect(args[1]).to.equal('Unit | Component | my-component')
+        expect(args[1]).to.equal('Unit / Component / my-component')
       })
 
       it('should set unit to true in options', function () {
@@ -48,7 +48,7 @@ describe('describeComponent()', function () {
     })
 
     it('should give proper test description', function () {
-      expect(args[1]).to.equal('Integration | Component | my-component')
+      expect(args[1]).to.equal('Integration / Component / my-component')
     })
 
     it('should set integration to true in options', function () {

--- a/tests/unit/describe-model-test.js
+++ b/tests/unit/describe-model-test.js
@@ -18,7 +18,7 @@ describe('describeModel()', function () {
       })
 
       it('should give proper test description', function () {
-        expect(args[1]).to.equal('Unit | Model | person')
+        expect(args[1]).to.equal('Unit / Model / person')
       })
 
       it('should give blank options', function () {
@@ -49,7 +49,7 @@ describe('describeModel()', function () {
       })
 
       it('should give proper test description', function () {
-        expect(args[1]).to.equal('Unit | Serializer | company')
+        expect(args[1]).to.equal('Unit / Serializer / company')
       })
 
       it('should give blank options', function () {

--- a/tests/unit/describe-module-test.js
+++ b/tests/unit/describe-module-test.js
@@ -18,7 +18,7 @@ describe('describeModule()', function () {
       })
 
       it('should give proper test description', function () {
-        expect(args[1]).to.equal('Unit | Route | thing')
+        expect(args[1]).to.equal('Unit / Route / thing')
       })
 
       it('should give blank options', function () {
@@ -49,7 +49,7 @@ describe('describeModule()', function () {
       })
 
       it('should give proper test description', function () {
-        expect(args[1]).to.equal('Unit | Controller | thing')
+        expect(args[1]).to.equal('Unit / Controller / thing')
       })
 
       it('should give blank options', function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change
### Overview

This PR alters the names generated by our describe-component, describe-model, and describe-module helpers so that the links in the interactive test webapp link to unique tests.

When using Ember's interactive test webapp (`ember test --launch Chrome --server`), the test names can be clicked to drill down to specific tests.  This links to a `grep` parameter with the name of the test:

```
?hidepassed&coverage&grep=Integration%20%2F%20Component%20%2F%20my-greeting
```

Unfortunately, using `|` in a test name (e.g. `Unit | Component | my-greeting`) leads the backend to grep for (`Unit` | `Component` | `my-greeting`) -- which will return the list of all the tests that have _Component_ in the name.  We fix this by naming tests e.g. `Unit / Component / my-greeting`
# CHANGELOG
- **Fixed** generated test names to use `/` instead of `|` as the test name separator, grep-ing the interactive web app can link to unique tests.
