### PR TITLE
Improve reporter

### DIFF
--- a/reporter.js
+++ b/reporter.js
@@ -58,22 +58,6 @@ function testWriter (test) {
 }
 
 /**
- * Write failed tests
- */
-function writeFailedTests () {
-  if (this.failedTests.length !== 0) {
-    this.out.write('FAILED TESTS\n\n')
-
-    this.failedTests
-      .sort(testSorter)
-      .reverse()
-      .forEach(testWriter.bind(this))
-
-    this.out.write('\n')
-  }
-}
-
-/**
  * Write passed tests
  */
 function writePassedTests () {
@@ -82,7 +66,6 @@ function writePassedTests () {
 
     this.passedTests
       .sort(testSorter)
-      .reverse()
       .forEach(testWriter.bind(this))
 
     this.out.write('\n')
@@ -137,9 +120,13 @@ Reporter.prototype = {
     var duration = Math.round(this.endTime - this.startTime)
     var humanReadableDuration = getHumanReadableDuration(duration)
 
-    writeSummary.call(this, humanReadableDuration)
-    writeFailedTests.call(this)
-    writePassedTests.call(this)
+    if (this.failedTests.length === 0) {
+      writeSummary.call(this, humanReadableDuration)
+      writePassedTests.call(this)
+    } else {
+      this.out.write('\n')
+    }
+
     writeSummary.call(this, humanReadableDuration)
   },
 
@@ -150,6 +137,7 @@ Reporter.prototype = {
       this.pass++
       this.passedTests.push(data)
     } else {
+      testWriter.call(this, data)
       this.failedTests.push(data)
     }
 

--- a/reporter.js
+++ b/reporter.js
@@ -51,10 +51,29 @@ function testSorter (a, b) {
  * Write out individual test result
  * @param {TestResult} test - test to write out result of
  */
-function testWriter (test) {
+function testWriter (test, verbose) {
   // Other properties that may be useful: logs, error, launcherId, items
   var humanFriendlyDuration = getHumanReadableDuration(test.runDuration)
   this.out.write('[' + humanFriendlyDuration + '] ' + test.name + '\n')
+
+  if (verbose) {
+    if (test.logs && test.logs.length !== 0) {
+      this.out.write('\tLogs:\n')
+
+      test.logs.forEach((log) => {
+        this.out.write('\t\t' + log + '\n')
+      })
+    }
+
+    if (test.error) {
+      var e = test.error
+      this.out.write('\n\tError: ' + e.message + '\n')
+
+      if (e.stack) {
+        this.out.write('\n\t\t' + e.stack.toString().replace(/\n/g, '\n\t\t') + '\n\n')
+      }
+    }
+  }
 }
 
 /**
@@ -137,12 +156,9 @@ Reporter.prototype = {
       this.pass++
       this.passedTests.push(data)
     } else {
-      if (this.failedTests.length === 0) {
-        this.out.write('FAILED TESTS\n\n')
-      }
-
-      testWriter.call(this, data)
+      this.out.write(this.failedTests.length === 0 ? 'FAILED TESTS\n\n' : '\n')
       this.failedTests.push(data)
+      testWriter.call(this, data, true)
     }
 
     this.total++

--- a/reporter.js
+++ b/reporter.js
@@ -137,6 +137,10 @@ Reporter.prototype = {
       this.pass++
       this.passedTests.push(data)
     } else {
+      if (this.failedTests.length === 0) {
+        this.out.write('FAILED TESTS\n\n')
+      }
+
       testWriter.call(this, data)
       this.failedTests.push(data)
     }

--- a/reporter.js
+++ b/reporter.js
@@ -50,6 +50,7 @@ function testSorter (a, b) {
 /**
  * Write out individual test result
  * @param {TestResult} test - test to write out result of
+ * @param {Boolean} verbose - whether or not to show additional error information
  */
 function testWriter (test, verbose) {
   // Other properties that may be useful: logs, error, launcherId, items


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Improved** custom mocha reporter to show failures as they occur and only show passed tests when all pass (now sorting fastest to slowest to reduce a user from having to scroll as much in their terminal).

When there are failures without stack traces it'll look like this:
<img width="1205" alt="screen shot 2016-12-01 at 3 00 46 pm" src="https://cloud.githubusercontent.com/assets/422902/20816671/639871d8-b7d8-11e6-86e9-e85830e87a37.png">

When there are failures with stack traces it'll look like this:
<img width="1146" alt="screen shot 2016-12-01 at 3 08 34 pm" src="https://cloud.githubusercontent.com/assets/422902/20816680/6c772c68-b7d8-11e6-814e-92bc9a15b961.png">

When all tests pass it'll look like this:
<img width="1270" alt="screen shot 2016-12-01 at 2 06 57 pm" src="https://cloud.githubusercontent.com/assets/422902/20814645/71377978-b7cf-11e6-9b6d-01d682e448be.png">
