### PR TITLE
Add ember-try setup for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,46 @@
-language: node_js
 sudo: false
-node_js:
-- '5.3'
-branches:
-  except:
-  - /^v[0-9\.]+/
-before_install:
-- npm install -g coveralls pr-bumper
-- pr-bumper check
-before_script:
-- "export DISPLAY=:99.0"
-- "sh -e /etc/init.d/xvfb start"
-- sleep 3
-install:
-- npm install
-- bower install
-after_success:
-- sed -i -- 's/SF:ember-test-utils\/\(.*\)/SF:addon\/\1.js/' coverage/lcov.info &&
-  rm -f coverage/lcov.info--
-- cat coverage/lcov.info | coveralls
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
+    - google-chrome
     packages:
+    - google-chrome-stable
     - g++-4.8
+language: node_js
+node_js:
+- '6.9'
+- 'stable'
+branches:
+  except:
+  - /^v[0-9\.]+/
+before_install:
+- "export DISPLAY=:99.0"
+- "sh -e /etc/init.d/xvfb start"
+- npm config set spin false
+- npm install -g coveralls pr-bumper --ignore-scripts
+- pr-bumper check
+install:
+- npm install ember-cli-sass # NOTE: this requies scripts
+- npm install --ignore-scripts
+- ./node_modules/.bin/bower install
+script:
+- npm run lint
+- npm run ci-test
+after_success:
+- .travis/publish-coverage.sh
 env:
   matrix:
-  - CXX=g++-4.8
+  - EMBER_TRY_SCENARIO=ember-2-3
+  - EMBER_TRY_SCENARIO=default
+  - EMBER_TRY_SCENARIO=ember-release
   global:
-    secure: ijqY3dg0KFt0W5vtfZzFn5gCX9tl4+R99cMGCXUEwilhleDm2SCUCz+nAgkcQUA1pkW2VVlG/GtpYnPDG1yq8sR9tVrYzsn86u0Mj+ow04JH+tAYc55IkqpfXfHe4vyEzrHj7RtczOkLKLAyHQlco5f8Cq+e5RdZ3EGyjEgP8bwLBPbn3n4lYQRw87xFRjsmSkrk5VLL3xEg/P+V/kJgEBXKEWU8k2OrOlSarMvP4+hCNiUCNsjEdvKeWxs1soq7SIqoTChwPiFtOA8EvxTK/GFoZMjSBvSCO/EhzIXosUFfHRwYTrJkR4RaKSi/qxTRTsrams4e6NBLlYQ6MpnBRxzkRs/XgJ/v2krhTH4Ki/w2vN7rSLzlE50h8YG9NaAh3uI99vnFto9kguSwzdN7x/v0gM7WM2SmZ2LQJMQwhT1k3/dtPGmL7RB5XTV/+Nstf41PGxvPUrw9zu6iAsyfV+6a8KgvCOTkS+z9SXZ1AzAAhpSe2aonTs8Qukzsf84c70YtdsuD+fv1B+dpes4VwOpk8VcBl6gTcicQ1e/HeWD2OOq9QsILKjrpI+x5tezs5/Mkcj9VhZE8hqqQ/ByEY4/cNlWXwtv/BRV3iaxlTsu1IMCb+/wZcNqv6ENonI6yrXKORZT3ivs5WUHRZQ1DCD3dZuoVtoDJpTsYgEdm55Y=
+    - CXX=g++-4.8
+    - secure: ijqY3dg0KFt0W5vtfZzFn5gCX9tl4+R99cMGCXUEwilhleDm2SCUCz+nAgkcQUA1pkW2VVlG/GtpYnPDG1yq8sR9tVrYzsn86u0Mj+ow04JH+tAYc55IkqpfXfHe4vyEzrHj7RtczOkLKLAyHQlco5f8Cq+e5RdZ3EGyjEgP8bwLBPbn3n4lYQRw87xFRjsmSkrk5VLL3xEg/P+V/kJgEBXKEWU8k2OrOlSarMvP4+hCNiUCNsjEdvKeWxs1soq7SIqoTChwPiFtOA8EvxTK/GFoZMjSBvSCO/EhzIXosUFfHRwYTrJkR4RaKSi/qxTRTsrams4e6NBLlYQ6MpnBRxzkRs/XgJ/v2krhTH4Ki/w2vN7rSLzlE50h8YG9NaAh3uI99vnFto9kguSwzdN7x/v0gM7WM2SmZ2LQJMQwhT1k3/dtPGmL7RB5XTV/+Nstf41PGxvPUrw9zu6iAsyfV+6a8KgvCOTkS+z9SXZ1AzAAhpSe2aonTs8Qukzsf84c70YtdsuD+fv1B+dpes4VwOpk8VcBl6gTcicQ1e/HeWD2OOq9QsILKjrpI+x5tezs5/Mkcj9VhZE8hqqQ/ByEY4/cNlWXwtv/BRV3iaxlTsu1IMCb+/wZcNqv6ENonI6yrXKORZT3ivs5WUHRZQ1DCD3dZuoVtoDJpTsYgEdm55Y=
+matrix:
+  fast_finish: true
+  allow_failures:
+  - env: EMBER_TRY_SCENARIO=ember-release
 before_deploy:
 - pr-bumper bump
 deploy:
@@ -40,7 +51,11 @@ deploy:
     secure: pVKvxzP7Ya6FexNohTyzI9jwceeUC0J0C7b6K8GqVTG2m/uFrnrNqQSqbZxc4LwHb5rMfwydCBh9GQfxsLSQQcvGRMaP+tJopfDGUWvtmHSosqlDyGuSFkrFmD9KhTQ3plBwtqsXvMpirRjtxrgXyd5G/9H1GywJ2dvihamt7JT4NGTONIBugcXdlxqAes3lWrNtwP9d+Zly5dU7PR+DB5DHa3KJRDmg66yiGBL1VvIrmObAqa/9N752Yi2pQgDyDUNzQpW3LuMQlWVo+DPRfNmDIi8EwYIyZiCd/faNqvI4fxRS1fgmm6L59b+oRVi+DHG/wod+/gjnP0+fa0YcWIm3KyYwfXxH4TEsyS/x3b1KcQUibcc2+HzywInpXpuZfc7QPTULO2x5w0Ak41vLI6KSuepx+Te6yqV5MfY00x3iBZKuwvCZ/kFxO3Hx5Y9XfcAayNTbzK8PYkB65M1VBdoTovVz0PxKBwI54DtKe9dpDQOFr9tru0BeBftpbiqpK65On22sou7B/g6cVCWmBMOgSjuJYelWsEopie4IWCW2jjfBsZe1/IEqfvDrpBml0dn2h6LBQr7FrKmN3wvZAtY/IqNF6PGgQw2ucqbJ0cjOiRDpEGmFVMkDTJh4d3BQrsv8tzsBnVdjdYgbrMZm/ea39SlG3Hw7HcmJEOnL5X4=
   on:
     branch: master
+    condition: "$EMBER_TRY_SCENARIO = 'default'"
+    node: 'stable'
     tags: false
+after_deploy:
+- .travis/publish-gh-pages.sh
 notifications:
   slack:
     secure: cMVH8CRip764A60F6N2Mih6UHi88I8sibtOhiTAXniKgJg2xitdormEFU4CUCAbb0PlXnZs1EkgIb4h8BlBMtFNoU7cUryCnR7w9X1WNr+t9D+pPQZvOdQdAqfnuVkW9lYV7cRPlVl5q5pbOYEyMFOmUblghuB/4jJyfKZJJN024e6nOw3OjNmZWW6dxmF8dKgS+To8w9HFzCfXm7N0BRI8iwbDte0nDBTZxSX62ybr3OmZQ84uqmIqgwRjGWLazLyglDOfJqnK81elyjqyAAuoIhZkr4GBlW4DPWcQIBbRwVRr1h/oBG+3YTnPmKzMS3dYBbzqOe3Rd8V/OvIfLQ++6MdKMri40dWOpoT5iVcEEuRMG3vBzvOOee3p+AkrMzneC+jH9IU/uc4mXMmr9eFbR4VNzN/JOtbGt7aDPt4aA6Iq2bFrxlzMKK2W8fNmE78GxZUOaOVenzh4M6BbSNyXb72qmaR5jNqD7qOqJM2BzPfNEQ0I3bJVZzrIh9N4f+fPJNirhiZ0tBuYnFedmiI9aa4/qFf2qcb75vEHxKenALBs5U1J4SaVt2FuaG0u8JejfFHeUBsNbEG1JgPq2WgsFM0DEnqYyGoZjwldP2GW9dtGyQrvbuDX/H8+tW4hYYI/XPokHiBt+LlKN+kPpjW56W9zMK7w7b+mME6MHLmk=

--- a/.travis/publish-coverage.sh
+++ b/.travis/publish-coverage.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$EMBER_TRY_SCENARIO" != "default" ]
+then
+  echo "Skipping coverage publish for EMBER_TRY_SCENARIO ${EMBER_TRY_SCENARIO}"
+  exit 0
+fi
+
+cat coverage/lcov.info | coveralls

--- a/.travis/publish-gh-pages.sh
+++ b/.travis/publish-gh-pages.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+VERSION=`node -e "console.log(require('./package.json').version)"`
+TMP_GH_PAGES_DIR=.gh-pages-demo
+
+# We only want to deploy to gh-pages from "master"
+if [ "${TRAVIS_BRANCH}" != "master" ]
+then
+    echo "Skipping gh-pages publish for branch ${TRAVIS_BRANCH}"
+    exit 0
+fi
+
+ember build --prod
+git clone https://${GITHUB_TOKEN}@github.com/${TRAVIS_REPO_SLUG} ${TMP_GH_PAGES_DIR} > /dev/null 2>&1
+cd ${TMP_GH_PAGES_DIR}
+git checkout gh-pages
+git rm -rf *
+cp -r ../dist/* .
+git add --all
+git commit -m "[ci skip] Automated gh-pages commit of ${VERSION}"
+git push origin gh-pages > /dev/null 2>&1

--- a/config/coverage.js
+++ b/config/coverage.js
@@ -1,0 +1,9 @@
+module.exports = {
+  coverageEnvVar: 'COVERAGE',
+  coverageFolder: 'coverage',
+  useBabelInstrumenter: true,
+  excludes: [
+    '*/app/**/*',
+    '*/tests/**/*'
+  ]
+}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,6 +7,116 @@ module.exports = {
       }
     },
     {
+      name: 'ember-1-12',
+      bower: {
+        dependencies: {
+          'ember': '~1.12.0'
+        },
+        resolutions: {
+          'ember': '~1.12.0'
+        }
+      }
+    },
+    {
+      name: 'ember-1-13',
+      bower: {
+        dependencies: {
+          'ember': '~1.13.0'
+        },
+        resolutions: {
+          'ember': '~1.13.0'
+        }
+      }
+    },
+    {
+      name: 'ember-2-0',
+      bower: {
+        dependencies: {
+          'ember': '~2.0.0'
+        },
+        resolutions: {
+          'ember': '~2.0.0'
+        }
+      }
+    },
+    {
+      name: 'ember-2-1',
+      bower: {
+        dependencies: {
+          'ember': '~2.1.0'
+        },
+        resolutions: {
+          'ember': '~2.1.0'
+        }
+      }
+    },
+    {
+      name: 'ember-2-2',
+      bower: {
+        dependencies: {
+          'ember': '~2.2.0'
+        },
+        resolutions: {
+          'ember': '~2.2.0'
+        }
+      }
+    },
+    {
+      name: 'ember-2-3',
+      bower: {
+        dependencies: {
+          'ember': '~2.3.0'
+        },
+        resolutions: {
+          'ember': '~2.3.0'
+        }
+      }
+    },
+    {
+      name: 'ember-2-4',
+      bower: {
+        dependencies: {
+          'ember': '~2.4.0'
+        },
+        resolutions: {
+          'ember': '~2.4.0'
+        }
+      }
+    },
+    {
+      name: 'ember-2-5',
+      bower: {
+        dependencies: {
+          'ember': '~2.5.0'
+        },
+        resolutions: {
+          'ember': '~2.5.0'
+        }
+      }
+    },
+    {
+      name: 'ember-2-6',
+      bower: {
+        dependencies: {
+          'ember': '~2.6.0'
+        },
+        resolutions: {
+          'ember': '~2.6.0'
+        }
+      }
+    },
+    {
+      name: 'ember-2-8',
+      bower: {
+        dependencies: {
+          'ember': '~2.8.0'
+        },
+        resolutions: {
+          'ember': '~2.8.0'
+        }
+      }
+    },
+    {
       name: 'ember-release',
       bower: {
         dependencies: {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "ember build",
     "start": "ember server",
     "test": "npm run lint && ember test",
+    "ci-test": "ember try:one $EMBER_TRY_SCENARIO --- COVERAGE=true ember test",
     "lint": "eslint *.js addon app config test-support tests"
   },
   "repository": "git@github.com:ciena-blueplanet/ember-test-utils.git",

--- a/reporter.js
+++ b/reporter.js
@@ -44,7 +44,7 @@ function getHumanReadableDuration (value) {
  * @returns {Number} number indicating sort order
  */
 function testSorter (a, b) {
-  return a.runDuration - b.runDuration
+  return a.result.runDuration - b.result.runDuration
 }
 
 /**
@@ -59,7 +59,7 @@ function testWriter (test, verbose) {
 
   // Other properties that may be useful: logs, error, launcherId, items
   var humanFriendlyDuration = getHumanReadableDuration(result.runDuration)
-  this.out.write('[' + humanFriendlyDuration + '] ' + launcher + ' ' + result.name + '\n')
+  this.out.write('[' + humanFriendlyDuration + '] [' + launcher + '] ' + result.name + '\n')
 
   if (verbose) {
     if (result.logs && result.logs.length !== 0) {

--- a/reporter.js
+++ b/reporter.js
@@ -49,25 +49,29 @@ function testSorter (a, b) {
 
 /**
  * Write out individual test result
- * @param {TestResult} test - test to write out result of
+ * @param {Object} test - the test params
+ * @param {String} test.launcher - the launcher (browser) for the test
+ * @param {TestResult} test.result - test to write out result of
  * @param {Boolean} verbose - whether or not to show additional error information
  */
 function testWriter (test, verbose) {
+  const {launcher, result} = test
+
   // Other properties that may be useful: logs, error, launcherId, items
-  var humanFriendlyDuration = getHumanReadableDuration(test.runDuration)
-  this.out.write('[' + humanFriendlyDuration + '] ' + test.name + '\n')
+  var humanFriendlyDuration = getHumanReadableDuration(result.runDuration)
+  this.out.write('[' + humanFriendlyDuration + '] ' + launcher + ' ' + result.name + '\n')
 
   if (verbose) {
-    if (test.logs && test.logs.length !== 0) {
+    if (result.logs && result.logs.length !== 0) {
       this.out.write('\tLogs:\n')
 
-      test.logs.forEach((log) => {
+      result.logs.forEach((log) => {
         this.out.write('\t\t' + log + '\n')
       })
     }
 
-    if (test.error) {
-      var e = test.error
+    if (result.error) {
+      var e = result.error
       this.out.write('\n\tError: ' + e.message + '\n')
 
       if (e.stack) {

--- a/reporter.js
+++ b/reporter.js
@@ -155,10 +155,16 @@ Reporter.prototype = {
       this.skipped++
     } else if (data.passed) {
       this.pass++
-      this.passedTests.push(data)
+      this.passedTests.push({
+        launcher: prefix,
+        result: data
+      })
     } else {
       this.out.write(this.failedTests.length === 0 ? 'FAILED TESTS\n\n' : '\n')
-      this.failedTests.push(data)
+      this.failedTests.push({
+        launcher: prefix,
+        result: data
+      })
       testWriter.call(this, data, true)
     }
 

--- a/test-support/helpers/ember-test-utils/describe-component.js
+++ b/test-support/helpers/ember-test-utils/describe-component.js
@@ -2,12 +2,11 @@
  * Shortcuts for generating the params passed to describeComponent from ember-mocha
  */
 
-import Ember from 'ember'
-const {assign} = Ember
-// NOTE not destructuring 'deprecate' for ease of testing
+import Ember from 'ember' // NOTE: not destructuring 'deprecate' for ease of testing
 
 import {getDeprecationMessage} from './typedefs'
 const deprecationMsg = getDeprecationMessage('describeComponent')
+const assign = Ember.assign || Ember.merge // NOTE: only use two params in assign() since merge() doesn't take more
 
 /**
  * A shortcut for filling in the first three params in a describeComponent

--- a/test-support/helpers/ember-test-utils/setup-component-test.js
+++ b/test-support/helpers/ember-test-utils/setup-component-test.js
@@ -4,8 +4,8 @@
 import './typedefs'
 
 import Ember from 'ember'
-const {assign} = Ember
 import {setupComponentTest} from 'ember-mocha'
+const assign = Ember.assign || Ember.merge // NOTE: only use two params in assign() since merge() doesn't take more
 
 // Workaround to allow stubbing dependencies during testing
 export const deps = {

--- a/test-support/helpers/ember-test-utils/setup-component-test.js
+++ b/test-support/helpers/ember-test-utils/setup-component-test.js
@@ -21,7 +21,7 @@ export const deps = {
 function component (name, options = {}) {
   const testType = (options.unit) ? 'Unit' : 'Integration'
   return {
-    label: `${testType} / Component / ${name}`,
+    label: `${testType} / Component / ${name} /`,
     setup () {
       deps.setupComponentTest(name, options)
     }

--- a/test-support/helpers/ember-test-utils/setup-test.js
+++ b/test-support/helpers/ember-test-utils/setup-test.js
@@ -26,7 +26,7 @@ export function module (name, options = {}) {
   const testType = (options.unit) ? 'Unit' : 'Integration'
   const [moduleType, moduleName] = name.split(':')
   return {
-    label: `${testType} / ${Ember.String.classify(moduleType)} / ${moduleName}`,
+    label: `${testType} / ${Ember.String.classify(moduleType)} / ${moduleName} /`,
     setup () {
       deps.setupTest(name, options)
     }
@@ -51,7 +51,7 @@ export function model (name, dependencies, options = {}) {
 
   const testType = (options.unit) ? 'Unit' : 'Integration'
   return {
-    label: `${testType} / Model / ${name}`,
+    label: `${testType} / Model / ${name} /`,
     setup () {
       deps.setupModelTest(name, options)
     }
@@ -79,7 +79,7 @@ export function serializer (name, dependencies = [], options = {}) {
 
   const testType = (options.unit) ? 'Unit' : 'Integration'
   return {
-    label: `${testType} / Serializer / ${name}`,
+    label: `${testType} / Serializer / ${name} /`,
     setup () {
       deps.setupModelTest(name, options)
     }

--- a/testem.js
+++ b/testem.js
@@ -1,4 +1,4 @@
-// var Reporter = require('./reporter')
+const Reporter = require('./reporter')
 
 module.exports = {
   framework: 'mocha',
@@ -9,6 +9,6 @@ module.exports = {
   ],
   launch_in_dev: [
     'Chrome'
-  ]
-  // reporter: new Reporter()
+  ],
+  reporter: new Reporter()
 }

--- a/testem.js
+++ b/testem.js
@@ -5,7 +5,7 @@ module.exports = {
   test_page: 'tests/index.html?hidepassed&coverage',
   disable_watching: true,
   launch_in_ci: [
-    'Firefox'
+    'Chrome', 'Firefox'
   ],
   launch_in_dev: [
     'Chrome'

--- a/testem.js
+++ b/testem.js
@@ -1,4 +1,4 @@
-var Reporter = require('./reporter')
+// var Reporter = require('./reporter')
 
 module.exports = {
   framework: 'mocha',
@@ -9,6 +9,6 @@ module.exports = {
   ],
   launch_in_dev: [
     'Chrome'
-  ],
-  reporter: new Reporter()
+  ]
+  // reporter: new Reporter()
 }

--- a/tests/unit/setup-component-test-test.js
+++ b/tests/unit/setup-component-test-test.js
@@ -27,7 +27,7 @@ describe('setupComponentTest()', function () {
       })
 
       it('should create proper describe label', function () {
-        expect(test.label).to.equal('Unit / Component / my-component')
+        expect(test.label).to.equal('Unit / Component / my-component /')
       })
 
       describe('when .setup() is called', function () {
@@ -47,7 +47,7 @@ describe('setupComponentTest()', function () {
       })
 
       it('should create proper describe label', function () {
-        expect(test.label).to.equal('Unit / Component / my-component')
+        expect(test.label).to.equal('Unit / Component / my-component /')
       })
 
       describe('when .setup() is called', function () {
@@ -72,7 +72,7 @@ describe('setupComponentTest()', function () {
     })
 
     it('should create proper describe label', function () {
-      expect(test.label).to.equal('Integration / Component / my-component')
+      expect(test.label).to.equal('Integration / Component / my-component /')
     })
 
     describe('when .setup() is called', function () {

--- a/tests/unit/setup-test-test.js
+++ b/tests/unit/setup-test-test.js
@@ -28,7 +28,7 @@ describe('setupTest()', function () {
       })
 
       it('should create proper describe label', function () {
-        expect(test.label).to.equal('Unit / Foo / my-bar')
+        expect(test.label).to.equal('Unit / Foo / my-bar /')
       })
 
       describe('when .setup() is called', function () {
@@ -48,7 +48,7 @@ describe('setupTest()', function () {
       })
 
       it('should create proper describe label', function () {
-        expect(test.label).to.equal('Unit / Foo / my-bar')
+        expect(test.label).to.equal('Unit / Foo / my-bar /')
       })
 
       describe('when .setup() is called', function () {
@@ -74,7 +74,7 @@ describe('setupTest()', function () {
       })
 
       it('should create proper describe label', function () {
-        expect(test.label).to.equal('Unit / Model / my-bar')
+        expect(test.label).to.equal('Unit / Model / my-bar /')
       })
 
       describe('when .setup() is called', function () {
@@ -94,7 +94,7 @@ describe('setupTest()', function () {
       })
 
       it('should create proper describe label', function () {
-        expect(test.label).to.equal('Unit / Model / my-bar')
+        expect(test.label).to.equal('Unit / Model / my-bar /')
       })
 
       describe('when .setup() is called', function () {
@@ -120,7 +120,7 @@ describe('setupTest()', function () {
       })
 
       it('should create proper describe label', function () {
-        expect(test.label).to.equal('Unit / Serializer / my-bar')
+        expect(test.label).to.equal('Unit / Serializer / my-bar /')
       })
 
       describe('when .setup() is called', function () {
@@ -140,7 +140,7 @@ describe('setupTest()', function () {
       })
 
       it('should create proper describe label', function () {
-        expect(test.label).to.equal('Unit / Serializer / my-bar')
+        expect(test.label).to.equal('Unit / Serializer / my-bar /')
       })
 
       describe('when .setup() is called', function () {
@@ -166,7 +166,7 @@ describe('setupTest()', function () {
       })
 
       it('should create proper describe label', function () {
-        expect(test.label).to.equal('Unit / Route / my-bar')
+        expect(test.label).to.equal('Unit / Route / my-bar /')
       })
 
       describe('when .setup() is called', function () {
@@ -186,7 +186,7 @@ describe('setupTest()', function () {
       })
 
       it('should create proper describe label', function () {
-        expect(test.label).to.equal('Unit / Route / my-bar')
+        expect(test.label).to.equal('Unit / Route / my-bar /')
       })
 
       describe('when .setup() is called', function () {
@@ -212,7 +212,7 @@ describe('setupTest()', function () {
       })
 
       it('should create proper describe label', function () {
-        expect(test.label).to.equal('Unit / Controller / my-bar')
+        expect(test.label).to.equal('Unit / Controller / my-bar /')
       })
 
       describe('when .setup() is called', function () {
@@ -232,7 +232,7 @@ describe('setupTest()', function () {
       })
 
       it('should create proper describe label', function () {
-        expect(test.label).to.equal('Unit / Controller / my-bar')
+        expect(test.label).to.equal('Unit / Controller / my-bar /')
       })
 
       describe('when .setup() is called', function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Added** tests for use with old versions of ember
* **Fixed** issue when used with `ember@2.3` (no `Ember.assign` available)
