### PR TITLE
Add ember-intl support

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-resolver": "^2.0.3",
     "ember-sinon": "^0.6.0",
     "eslint": "^3.7.0",
-    "eslint-config-frost-standard": "^5.0.0",
+    "eslint-config-frost-standard": "^5.3.1",
     "loader.js": "^4.0.0"
   },
   "keywords": [

--- a/test-support/helpers/ember-test-utils/describe-component.js
+++ b/test-support/helpers/ember-test-utils/describe-component.js
@@ -2,7 +2,9 @@
  * Shortcuts for generating the params passed to describeComponent from ember-mocha
  */
 
-import Ember from 'ember' // NOTE: not destructuring 'deprecate' for ease of testing
+// NOTE: not destructuring 'deprecate' for ease of testing
+/* eslint-disable ember-standard/destructure */
+import Ember from 'ember'
 
 import {getDeprecationMessage} from './typedefs'
 const deprecationMsg = getDeprecationMessage('describeComponent')

--- a/test-support/helpers/ember-test-utils/describe-model.js
+++ b/test-support/helpers/ember-test-utils/describe-model.js
@@ -2,10 +2,12 @@
  * Shortcut for generating the params passed to describeModel from ember-mocha
  */
 
+// NOTE not destructuring 'deprecate' for ease of testing
+/* eslint-disable ember-standard/destructure */
 import Ember from 'ember'
+
 import {getDeprecationMessage} from './typedefs'
 
-// NOTE not destructuring 'deprecate' for ease of testing
 const deprecationMsg = getDeprecationMessage('describeModel')
 
 /**

--- a/test-support/helpers/ember-test-utils/describe-module.js
+++ b/test-support/helpers/ember-test-utils/describe-module.js
@@ -2,7 +2,9 @@
  * Shortcut for generating the params passed to describeModule from ember-mocha
  */
 
-import Ember from 'ember' // NOTE not destructuring 'deprecate' for ease of testing
+// NOTE not destructuring 'deprecate' for ease of testing
+/* eslint-disable ember-standard/destructure */
+import Ember from 'ember'
 
 import {getDeprecationMessage} from './typedefs'
 const deprecationMsg = getDeprecationMessage('describeModule')

--- a/test-support/helpers/ember-test-utils/ember-intl.js
+++ b/test-support/helpers/ember-test-utils/ember-intl.js
@@ -1,0 +1,43 @@
+/**
+ * Helpers for doing tests with ember-intl
+ */
+
+/**
+ * Additional ember-intl dependencies
+ * @see {@link https://github.com/jasonmit/ember-intl/blob/master/docs/unit-testing.md#unit-testing}
+ */
+export const emberIntlDeps = [
+  'ember-intl@adapter:default', // required with format-message
+  'ember-intl@formatter:format-message', // optional
+  'ember-intl@formatter:format-html-message', // optional
+  'ember-intl@formatter:format-date', // optional
+  'ember-intl@formatter:format-time', // optional
+  'ember-intl@formatter:format-number', // optional
+  'ember-intl@formatter:format-relative', // optional
+  'helper:intl-get', // optional
+  'helper:t', // optional, if used then be sure to include the format-message formatter above
+  'helper:t-html', // optional, if used then be sure to include the format-html-message formatter above
+  'helper:format-date', // optional
+  'helper:format-time', // optional
+  'helper:format-relative', // optional
+  'helper:format-number' // optional
+]
+
+/**
+ * Add all the dependencies listed as required or optional from ember-intl documentation
+ * @param {String[]} deps - the list of dependencies (it will be mutated)
+ */
+export function addEmberIntlDeps (deps) {
+  emberIntlDeps.forEach((dep) => {
+    deps.push(dep)
+  })
+}
+
+/**
+ * Check if a given set of options requires additional ember-intl dependencies
+ * @param {Object} options - the options for the test
+ * @returns {Boolean} true if additional ember-intl dependencies are needed
+ */
+export function needsEmberIntlDeps (options) {
+  return (options.unit === true) && (options.needs !== undefined) && options.needs.includes('service:intl')
+}

--- a/test-support/helpers/ember-test-utils/object-diff.js
+++ b/test-support/helpers/ember-test-utils/object-diff.js
@@ -2,6 +2,8 @@
 /* eslint-disable complexity */
 
 import Ember from 'ember'
+const {deprecate} = Ember
+
 import _ from 'lodash'
 
 export const ARRAY_PLACEHOLDER = '<%ARRAY_PLACEHOLDER%> elements equal'
@@ -103,7 +105,7 @@ function diffArray (obj1Value, obj2Value) {
 }
 
 export default function diffObject (obj1, obj2) {
-  Ember.deprecate(
+  deprecate(
     'diffObject is deprecated, and will soon be removed. Hopefully to be replaced with a chai helper',
     false,
     {

--- a/test-support/helpers/ember-test-utils/setup-component-test.js
+++ b/test-support/helpers/ember-test-utils/setup-component-test.js
@@ -1,14 +1,19 @@
 /**
  * Helper for streamlining setting up component tests
  */
-import './typedefs'
 
+/* eslint-disable ember-standard/destructure */
 import Ember from 'ember'
 import {setupComponentTest} from 'ember-mocha'
 const assign = Ember.assign || Ember.merge // NOTE: only use two params in assign() since merge() doesn't take more
 
+import {addEmberIntlDeps, needsEmberIntlDeps} from './ember-intl'
+import './typedefs'
+
 // Workaround to allow stubbing dependencies during testing
 export const deps = {
+  addEmberIntlDeps,
+  needsEmberIntlDeps,
   setupComponentTest
 }
 
@@ -20,6 +25,11 @@ export const deps = {
  */
 function component (name, options = {}) {
   const testType = (options.unit) ? 'Unit' : 'Integration'
+
+  if (deps.needsEmberIntlDeps(options)) {
+    deps.addEmberIntlDeps(options.needs)
+  }
+
   return {
     label: `${testType} / Component / ${name} /`,
     setup () {

--- a/test-support/helpers/ember-test-utils/setup-test.js
+++ b/test-support/helpers/ember-test-utils/setup-test.js
@@ -1,13 +1,17 @@
 /**
  * Helper for streamlining setting up mocha tests
  */
-import './typedefs'
 
 import Ember from 'ember'
 import {setupModelTest, setupTest} from 'ember-mocha'
 
+import {addEmberIntlDeps, needsEmberIntlDeps} from './ember-intl'
+import './typedefs'
+
 // Workaround to allow stubbing dependencies during testing
 export const deps = {
+  addEmberIntlDeps,
+  needsEmberIntlDeps,
   setupModelTest,
   setupTest
 }
@@ -21,6 +25,10 @@ export const deps = {
 export function module (name, options = {}) {
   if (!options.unit && !options.integration) {
     options.unit = true
+  }
+
+  if (deps.needsEmberIntlDeps(options)) {
+    deps.addEmberIntlDeps(options.needs)
   }
 
   const testType = (options.unit) ? 'Unit' : 'Integration'
@@ -49,6 +57,10 @@ export function model (name, dependencies, options = {}) {
     options.unit = true
   }
 
+  if (deps.needsEmberIntlDeps(options)) {
+    deps.addEmberIntlDeps(options.needs)
+  }
+
   const testType = (options.unit) ? 'Unit' : 'Integration'
   return {
     label: `${testType} / Model / ${name} /`,
@@ -75,6 +87,10 @@ export function serializer (name, dependencies = [], options = {}) {
 
   if (!options.unit && !options.integration) {
     options.unit = true
+  }
+
+  if (deps.needsEmberIntlDeps(options)) {
+    deps.addEmberIntlDeps(options.needs)
   }
 
   const testType = (options.unit) ? 'Unit' : 'Integration'

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,13 +1,15 @@
 import Ember from 'ember'
-import Resolver from './resolver'
-import loadInitializers from 'ember-load-initializers'
+const {Application} = Ember
+
 import config from './config/environment'
+import loadInitializers from 'ember-load-initializers'
+import Resolver from './resolver'
 
 let App
 
 Ember.MODEL_FACTORY_INJECTIONS = true
 
-App = Ember.Application.extend({
+App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/tests/dummy/app/models/company.js
+++ b/tests/dummy/app/models/company.js
@@ -1,9 +1,9 @@
 /**
  * dummy company model
  */
-import DS from 'ember-data'
-const {Model, attr} = DS
 import computed, {readOnly} from 'ember-computed-decorators'
+const {Model, attr} = DS
+import DS from 'ember-data'
 
 export default Model.extend({
   name: attr('string'),

--- a/tests/dummy/app/models/person.js
+++ b/tests/dummy/app/models/person.js
@@ -1,9 +1,9 @@
 /**
  * Dummy person model
  */
-import DS from 'ember-data'
-const {Model, attr, belongsTo} = DS
 import computed, {readOnly} from 'ember-computed-decorators'
+const {Model, attr, belongsTo} = DS
+import DS from 'ember-data'
 
 export default Model.extend({
   company: belongsTo('company'),

--- a/tests/dummy/app/pods/application/controller.js
+++ b/tests/dummy/app/pods/application/controller.js
@@ -1,4 +1,5 @@
 import Ember from 'ember'
+const {Controller} = Ember
 
-export default Ember.Controller.extend({
+export default Controller.extend({
 })

--- a/tests/dummy/app/pods/application/route.js
+++ b/tests/dummy/app/pods/application/route.js
@@ -1,4 +1,5 @@
 import Ember from 'ember'
+const {Route} = Ember
 
-export default Ember.Route.extend({
+export default Route.extend({
 })

--- a/tests/dummy/app/pods/demo/route.js
+++ b/tests/dummy/app/pods/demo/route.js
@@ -1,6 +1,7 @@
 import Ember from 'ember'
+const {Route} = Ember
 
-export default Ember.Route.extend({
+export default Route.extend({
   model () {
     return {
       username: 'tony.stark'

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -1,12 +1,14 @@
 import Ember from 'ember'
+const {Router} = Ember
+
 import config from './config/environment'
 
-var Router = Ember.Router.extend({
+var MyRouter = Router.extend({
   location: config.locationType
 })
 
-Router.map(function () {
-  this.route('demo', { path: '/' })
+MyRouter.map(function () {
+  this.route('demo', {path: '/'})
 })
 
-export default Router
+export default MyRouter

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,6 @@
 import Ember from 'ember'
+const {run} = Ember
 
 export default function destroyApp (application) {
-  Ember.run(application, 'destroy')
+  run(application, 'destroy')
 }

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,14 +1,16 @@
 import Ember from 'ember'
+const {merge, run} = Ember
+
 import Application from '../../app'
 import config from '../../config/environment'
 
 export default function startApp (attrs) {
   let application
 
-  let attributes = Ember.merge({}, config.APP)
-  attributes = Ember.merge(attributes, attrs) // use defaults, but you can override
+  let attributes = merge({}, config.APP)
+  attributes = merge(attributes, attrs) // use defaults, but you can override
 
-  Ember.run(() => {
+  run(() => {
     application = Application.create(attributes)
     application.setupForTesting()
     application.injectTestHelpers()

--- a/tests/integration/pods/my-greeting/component-test.js
+++ b/tests/integration/pods/my-greeting/component-test.js
@@ -2,8 +2,8 @@
  * Integration test of the my-greeting component
  */
 import {expect} from 'chai'
-import {beforeEach, describe, it} from 'mocha'
 import hbs from 'htmlbars-inline-precompile'
+import {beforeEach, describe, it} from 'mocha'
 import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 
 const test = integration('my-greeting')

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,4 +1,4 @@
 import resolver from './helpers/resolver'
-import { setResolver } from 'ember-mocha'
+import {setResolver} from 'ember-mocha'
 
 setResolver(resolver)

--- a/tests/unit/describe-component-test.js
+++ b/tests/unit/describe-component-test.js
@@ -3,11 +3,14 @@
  */
 
 import {expect} from 'chai'
+// NOTE: not destructuring 'deprecate' for ease of testing
+/* eslint-disable ember-standard/destructure */
 import Ember from 'ember'
+
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
-import {unit, integration} from 'dummy/tests/helpers/ember-test-utils/describe-component'
+import {integration, unit} from 'dummy/tests/helpers/ember-test-utils/describe-component'
 import {getDeprecationMessage} from 'dummy/tests/helpers/ember-test-utils/typedefs'
 
 const deprecationMsg = getDeprecationMessage('describeComponent')

--- a/tests/unit/describe-model-test.js
+++ b/tests/unit/describe-model-test.js
@@ -2,6 +2,9 @@
  * Unit tests for the describe-model module
  */
 import {expect} from 'chai'
+// NOTE: not destructuring 'deprecate' for ease of testing
+/* eslint-disable ember-standard/destructure */
+import Ember from 'ember'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 

--- a/tests/unit/describe-module-test.js
+++ b/tests/unit/describe-module-test.js
@@ -2,11 +2,14 @@
  * Unit tests for the describe-model module
  */
 import {expect} from 'chai'
+// NOTE: not destructuring 'deprecate' for ease of testing
+/* eslint-disable ember-standard/destructure */
 import Ember from 'ember'
+
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
-import {route, controller} from 'dummy/tests/helpers/ember-test-utils/describe-module'
+import {controller, route} from 'dummy/tests/helpers/ember-test-utils/describe-module'
 import {getDeprecationMessage} from 'dummy/tests/helpers/ember-test-utils/typedefs'
 
 const deprecationMsg = getDeprecationMessage('describeModule')

--- a/tests/unit/ember-intl-test.js
+++ b/tests/unit/ember-intl-test.js
@@ -1,0 +1,76 @@
+/**
+ * Unit tests for the setup-test module
+ */
+
+import {expect} from 'chai'
+import {beforeEach, describe, it} from 'mocha'
+
+import {addEmberIntlDeps, emberIntlDeps, needsEmberIntlDeps} from 'dummy/tests/helpers/ember-test-utils/ember-intl'
+
+describe('ember-intl', function () {
+  describe('addEmberIntlDeps()', function () {
+    let deps
+    beforeEach(function () {
+      deps = ['service:intl']
+      addEmberIntlDeps(deps)
+    })
+
+    emberIntlDeps.forEach((dep) => {
+      it(`should have "${dep}" added`, function () {
+        expect(deps).to.include(dep)
+      })
+    })
+  })
+
+  describe('needsEmberIntlDeps()', function () {
+    let options, ret
+    beforeEach(function () {
+      options = {}
+    })
+
+    describe('when not unit', function () {
+      beforeEach(function () {
+        ret = needsEmberIntlDeps(options)
+      })
+
+      it('should return false', function () {
+        expect(ret).to.equal(false)
+      })
+    })
+
+    describe('when unit without dependencies', function () {
+      beforeEach(function () {
+        options.unit = true
+        ret = needsEmberIntlDeps(options)
+      })
+
+      it('should return false', function () {
+        expect(ret).to.equal(false)
+      })
+    })
+
+    describe('when unit with dependencies, but not ember-intl', function () {
+      beforeEach(function () {
+        options.unit = true
+        options.needs = ['service:bar']
+        ret = needsEmberIntlDeps(options)
+      })
+
+      it('should return false', function () {
+        expect(ret).to.equal(false)
+      })
+    })
+
+    describe('when unit with ember-intl dependency', function () {
+      beforeEach(function () {
+        options.unit = true
+        options.needs = ['service:bar', 'service:intl', 'helper:foo']
+        ret = needsEmberIntlDeps(options)
+      })
+
+      it('should return true', function () {
+        expect(ret).to.equal(true)
+      })
+    })
+  })
+})

--- a/tests/unit/object-diff-test.js
+++ b/tests/unit/object-diff-test.js
@@ -1,8 +1,8 @@
 /**
  * Unit tests for the object-diff module
  */
-import _ from 'lodash'
 import {expect} from 'chai'
+import _ from 'lodash'
 import {describe, it} from 'mocha'
 import objectDiff, {ARRAY_PLACEHOLDER} from 'dummy/tests/helpers/ember-test-utils/object-diff'
 

--- a/tests/unit/setup-component-test-test.js
+++ b/tests/unit/setup-component-test-test.js
@@ -12,6 +12,8 @@ describe('setupComponentTest()', function () {
   let sandbox
   beforeEach(function () {
     sandbox = sinon.sandbox.create()
+    sandbox.stub(deps, 'addEmberIntlDeps')
+    sandbox.stub(deps, 'needsEmberIntlDeps')
     sandbox.stub(deps, 'setupComponentTest')
   })
 
@@ -30,6 +32,10 @@ describe('setupComponentTest()', function () {
         expect(test.label).to.equal('Unit / Component / my-component /')
       })
 
+      it('should check if ember-intl deps are needed', function () {
+        expect(deps.needsEmberIntlDeps).to.have.been.calledWith({unit: true})
+      })
+
       describe('when .setup() is called', function () {
         beforeEach(function () {
           test.setup()
@@ -42,12 +48,18 @@ describe('setupComponentTest()', function () {
     })
 
     describe('when dependencies are given', function () {
+      let needs
       beforeEach(function () {
-        test = unit('my-component', ['component:foo-bar', 'helper:baz'])
+        needs = ['component:foo-bar', 'helper:baz']
+        test = unit('my-component', needs)
       })
 
       it('should create proper describe label', function () {
         expect(test.label).to.equal('Unit / Component / my-component /')
+      })
+
+      it('should check if ember-intl deps are needed', function () {
+        expect(deps.needsEmberIntlDeps).to.have.been.calledWith({unit: true, needs})
       })
 
       describe('when .setup() is called', function () {
@@ -61,6 +73,30 @@ describe('setupComponentTest()', function () {
             unit: true
           })
         })
+      })
+    })
+
+    describe('when it does not need ember-intl deps', function () {
+      beforeEach(function () {
+        deps.needsEmberIntlDeps.returns(false)
+        test = unit('my-bar')
+      })
+
+      it('should not add ember-intl deps', function () {
+        expect(deps.addEmberIntlDeps).to.have.callCount(0)
+      })
+    })
+
+    describe('when it does need ember-intl deps', function () {
+      let needs
+      beforeEach(function () {
+        needs = ['foo:bar']
+        deps.needsEmberIntlDeps.returns(true)
+        test = unit('my-bar', needs)
+      })
+
+      it('should add ember-intl deps', function () {
+        expect(deps.addEmberIntlDeps).to.have.been.calledWith(needs)
       })
     })
   })
@@ -82,6 +118,17 @@ describe('setupComponentTest()', function () {
 
       it('should call setupComponentTest() with proper args', function () {
         expect(deps.setupComponentTest).to.have.been.calledWith('my-component', {integration: true})
+      })
+    })
+
+    describe('when it does not need ember-intl deps', function () {
+      beforeEach(function () {
+        deps.needsEmberIntlDeps.returns(false)
+        test = integration('my-bar')
+      })
+
+      it('should not add ember-intl deps', function () {
+        expect(deps.addEmberIntlDeps).to.have.callCount(0)
       })
     })
   })

--- a/tests/unit/setup-test-test.js
+++ b/tests/unit/setup-test-test.js
@@ -6,12 +6,14 @@ import {expect} from 'chai'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
-import {deps, module, model, serializer, route, controller} from 'dummy/tests/helpers/ember-test-utils/setup-test'
+import {controller, deps, model, module, route, serializer} from 'dummy/tests/helpers/ember-test-utils/setup-test'
 
 describe('setupTest()', function () {
   let sandbox
   beforeEach(function () {
     sandbox = sinon.sandbox.create()
+    sandbox.stub(deps, 'addEmberIntlDeps')
+    sandbox.stub(deps, 'needsEmberIntlDeps')
     sandbox.stub(deps, 'setupModelTest')
     sandbox.stub(deps, 'setupTest')
   })
@@ -31,6 +33,10 @@ describe('setupTest()', function () {
         expect(test.label).to.equal('Unit / Foo / my-bar /')
       })
 
+      it('should check if ember-intl deps are needed', function () {
+        expect(deps.needsEmberIntlDeps).to.have.been.calledWith({unit: true})
+      })
+
       describe('when .setup() is called', function () {
         beforeEach(function () {
           test.setup()
@@ -43,12 +49,18 @@ describe('setupTest()', function () {
     })
 
     describe('when dependencies are given', function () {
+      let options
       beforeEach(function () {
-        test = module('foo:my-bar', {needs: ['component:foo-bar', 'helper:baz']})
+        options = {needs: ['component:foo-bar', 'helper:baz']}
+        test = module('foo:my-bar', options)
       })
 
       it('should create proper describe label', function () {
         expect(test.label).to.equal('Unit / Foo / my-bar /')
+      })
+
+      it('should check if ember-intl deps are needed', function () {
+        expect(deps.needsEmberIntlDeps).to.have.been.calledWith(options)
       })
 
       describe('when .setup() is called', function () {
@@ -64,6 +76,30 @@ describe('setupTest()', function () {
         })
       })
     })
+
+    describe('when it does not need ember-intl deps', function () {
+      beforeEach(function () {
+        deps.needsEmberIntlDeps.returns(false)
+        test = module('foo:my-bar')
+      })
+
+      it('should not add ember-intl deps', function () {
+        expect(deps.addEmberIntlDeps).to.have.callCount(0)
+      })
+    })
+
+    describe('when it does need ember-intl deps', function () {
+      let needs
+      beforeEach(function () {
+        needs = ['foo:bar']
+        deps.needsEmberIntlDeps.returns(true)
+        test = module('foo:my-bar', {needs})
+      })
+
+      it('should add ember-intl deps', function () {
+        expect(deps.addEmberIntlDeps).to.have.been.calledWith(needs)
+      })
+    })
   })
 
   describe('model()', function () {
@@ -75,6 +111,10 @@ describe('setupTest()', function () {
 
       it('should create proper describe label', function () {
         expect(test.label).to.equal('Unit / Model / my-bar /')
+      })
+
+      it('should check if ember-intl deps are needed', function () {
+        expect(deps.needsEmberIntlDeps).to.have.been.calledWith({unit: true})
       })
 
       describe('when .setup() is called', function () {
@@ -89,12 +129,18 @@ describe('setupTest()', function () {
     })
 
     describe('when dependencies are given', function () {
+      let needs
       beforeEach(function () {
-        test = model('my-bar', ['component:foo-bar', 'helper:baz'])
+        needs = ['component:foo-bar', 'helper:baz']
+        test = model('my-bar', needs)
       })
 
       it('should create proper describe label', function () {
         expect(test.label).to.equal('Unit / Model / my-bar /')
+      })
+
+      it('should check if ember-intl deps are needed', function () {
+        expect(deps.needsEmberIntlDeps).to.have.been.calledWith({unit: true, needs})
       })
 
       describe('when .setup() is called', function () {
@@ -108,6 +154,30 @@ describe('setupTest()', function () {
             unit: true
           })
         })
+      })
+    })
+
+    describe('when it does not need ember-intl deps', function () {
+      beforeEach(function () {
+        deps.needsEmberIntlDeps.returns(false)
+        test = model('my-bar')
+      })
+
+      it('should not add ember-intl deps', function () {
+        expect(deps.addEmberIntlDeps).to.have.callCount(0)
+      })
+    })
+
+    describe('when it does need ember-intl deps', function () {
+      let needs
+      beforeEach(function () {
+        needs = ['foo:bar']
+        deps.needsEmberIntlDeps.returns(true)
+        test = model('my-bar', needs)
+      })
+
+      it('should add ember-intl deps', function () {
+        expect(deps.addEmberIntlDeps).to.have.been.calledWith(needs)
       })
     })
   })
@@ -123,6 +193,10 @@ describe('setupTest()', function () {
         expect(test.label).to.equal('Unit / Serializer / my-bar /')
       })
 
+      it('should check if ember-intl deps are needed', function () {
+        expect(deps.needsEmberIntlDeps).to.have.been.calledWith({unit: true, needs: ['model:my-bar']})
+      })
+
       describe('when .setup() is called', function () {
         beforeEach(function () {
           test.setup()
@@ -135,12 +209,18 @@ describe('setupTest()', function () {
     })
 
     describe('when dependencies are given', function () {
+      let needs
       beforeEach(function () {
+        needs = ['component:foo-bar', 'helper:baz']
         test = serializer('my-bar', ['component:foo-bar', 'helper:baz'])
       })
 
       it('should create proper describe label', function () {
         expect(test.label).to.equal('Unit / Serializer / my-bar /')
+      })
+
+      it('should check if ember-intl deps are needed', function () {
+        expect(deps.needsEmberIntlDeps).to.have.been.calledWith({unit: true, needs: needs.concat(['model:my-bar'])})
       })
 
       describe('when .setup() is called', function () {
@@ -156,6 +236,30 @@ describe('setupTest()', function () {
         })
       })
     })
+
+    describe('when it does not need ember-intl deps', function () {
+      beforeEach(function () {
+        deps.needsEmberIntlDeps.returns(false)
+        test = serializer('my-bar')
+      })
+
+      it('should not add ember-intl deps', function () {
+        expect(deps.addEmberIntlDeps).to.have.callCount(0)
+      })
+    })
+
+    describe('when it does need ember-intl deps', function () {
+      let needs
+      beforeEach(function () {
+        needs = ['foo:bar']
+        deps.needsEmberIntlDeps.returns(true)
+        test = serializer('my-bar', needs)
+      })
+
+      it('should add ember-intl deps', function () {
+        expect(deps.addEmberIntlDeps).to.have.been.calledWith(needs)
+      })
+    })
   })
 
   describe('route()', function () {
@@ -167,6 +271,10 @@ describe('setupTest()', function () {
 
       it('should create proper describe label', function () {
         expect(test.label).to.equal('Unit / Route / my-bar /')
+      })
+
+      it('should check if ember-intl deps are needed', function () {
+        expect(deps.needsEmberIntlDeps).to.have.been.calledWith({unit: true})
       })
 
       describe('when .setup() is called', function () {
@@ -181,12 +289,18 @@ describe('setupTest()', function () {
     })
 
     describe('when dependencies are given', function () {
+      let needs
       beforeEach(function () {
-        test = route('my-bar', ['component:foo-bar', 'helper:baz'])
+        needs = ['component:foo-bar', 'helper:baz']
+        test = route('my-bar', needs)
       })
 
       it('should create proper describe label', function () {
         expect(test.label).to.equal('Unit / Route / my-bar /')
+      })
+
+      it('should check if ember-intl deps are needed', function () {
+        expect(deps.needsEmberIntlDeps).to.have.been.calledWith({unit: true, needs})
       })
 
       describe('when .setup() is called', function () {
@@ -202,6 +316,30 @@ describe('setupTest()', function () {
         })
       })
     })
+
+    describe('when it does not need ember-intl deps', function () {
+      beforeEach(function () {
+        deps.needsEmberIntlDeps.returns(false)
+        test = route('my-bar')
+      })
+
+      it('should not add ember-intl deps', function () {
+        expect(deps.addEmberIntlDeps).to.have.callCount(0)
+      })
+    })
+
+    describe('when it does need ember-intl deps', function () {
+      let needs
+      beforeEach(function () {
+        needs = ['foo:bar']
+        deps.needsEmberIntlDeps.returns(true)
+        test = route('my-bar', needs)
+      })
+
+      it('should add ember-intl deps', function () {
+        expect(deps.addEmberIntlDeps).to.have.been.calledWith(needs)
+      })
+    })
   })
 
   describe('controller()', function () {
@@ -213,6 +351,10 @@ describe('setupTest()', function () {
 
       it('should create proper describe label', function () {
         expect(test.label).to.equal('Unit / Controller / my-bar /')
+      })
+
+      it('should check if ember-intl deps are needed', function () {
+        expect(deps.needsEmberIntlDeps).to.have.been.calledWith({unit: true})
       })
 
       describe('when .setup() is called', function () {
@@ -227,12 +369,18 @@ describe('setupTest()', function () {
     })
 
     describe('when dependencies are given', function () {
+      let needs
       beforeEach(function () {
-        test = controller('my-bar', ['component:foo-bar', 'helper:baz'])
+        needs = ['component:foo-bar', 'helper:baz']
+        test = controller('my-bar', needs)
       })
 
       it('should create proper describe label', function () {
         expect(test.label).to.equal('Unit / Controller / my-bar /')
+      })
+
+      it('should check if ember-intl deps are needed', function () {
+        expect(deps.needsEmberIntlDeps).to.have.been.calledWith({unit: true, needs})
       })
 
       describe('when .setup() is called', function () {
@@ -246,6 +394,30 @@ describe('setupTest()', function () {
             unit: true
           })
         })
+      })
+    })
+
+    describe('when it does not need ember-intl deps', function () {
+      beforeEach(function () {
+        deps.needsEmberIntlDeps.returns(false)
+        test = controller('my-bar')
+      })
+
+      it('should not add ember-intl deps', function () {
+        expect(deps.addEmberIntlDeps).to.have.callCount(0)
+      })
+    })
+
+    describe('when it does need ember-intl deps', function () {
+      let needs
+      beforeEach(function () {
+        needs = ['foo:bar']
+        deps.needsEmberIntlDeps.returns(true)
+        test = controller('my-bar', needs)
+      })
+
+      it('should add ember-intl deps', function () {
+        expect(deps.addEmberIntlDeps).to.have.been.calledWith(needs)
       })
     })
   })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Added** support to automatically add `ember-intl` dependencies to unit tests that specify `service:intl` in their dependencies
* **Updated** lint rules and fixed new warnings
