### PR TITLE
Change CI browser example

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ module.exports = {
   disable_watching: true,
   framework: 'mocha',
   launch_in_ci: [
-    'Firefox'
+    'Chrome'
   ],
   launch_in_dev: [
     'Chrome'


### PR DESCRIPTION
`ember-frost-core` now uses Chrome for both CI and dev environments

### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* Change CI browser example in *README.md* to match `ember-frost-core` usage