### PR TITLE
Add dots to reporter

### DIFF
--- a/reporter.js
+++ b/reporter.js
@@ -76,7 +76,7 @@ function testWriter (test, verbose) {
       this.out.write('\n\tError: ' + e.message + '\n')
 
       if (e.stack) {
-        this.out.write('\n\t\t' + e.stack.toString().replace(/\n/g, '\n\t\t') + '\n\n')
+        this.out.write('\n\t\t' + e.stack.toString().replace(/\n/g, '\n\t\t') + '\n')
       }
     }
   }
@@ -166,8 +166,9 @@ Reporter.prototype = {
     } else if (data.passed) {
       this.pass++
       this.passedTests.push(test)
+      this.out.write('.')
     } else {
-      this.out.write(this.failedTests.length === 0 ? 'FAILED TESTS\n\n' : '\n')
+      this.out.write('\n\n')
       this.failedTests.push(test)
       testWriter.call(this, test, true)
     }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Resolves #25

Below is what the output looks like (the dots print as tests pass).

<img width="1280" alt="screen shot 2017-02-01 at 6 54 46 am" src="https://cloud.githubusercontent.com/assets/422902/22511767/8905314c-e84b-11e6-84d1-0f4dc2f01bf0.png">

# CHANGELOG

* **Added** dots to test reporter so it is visually obvious tests are executing.
