### PR TITLE
Add template linting executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,30 @@ module.exports = {
 
 > NOTE: This reporter will group test results into two sections: failed and passed. Each section is sorted from slowest test to fastest test so you can see which tests are causing your CI to come to a crawl.
 
+## Template Linting
+
+If you want to lint your template files you can simply run:
+
+```bash
+./node_modules/.bin/template-lint
+```
+
+or even better add the following script to your `package.json`:
+
+```json
+{
+  "scripts": {
+    "lint-hbs": "template-lint"
+  }
+}
+```
+
+and run
+
+```bash
+npm run lint-hbs
+```
+
 ## Contributing
 
 This following outlines the details of collaborating on this Ember addon:

--- a/cli/template-lint.js
+++ b/cli/template-lint.js
@@ -7,6 +7,7 @@ const TemplateLinter = require('ember-template-lint')
 const linter = new TemplateLinter()
 
 const errors = glob.sync([
+  'addon/**/*.hbs',
   'app/**/*.hbs',
   'tests/**/*.hbs'
 ])

--- a/cli/template-lint.js
+++ b/cli/template-lint.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const glob = require('glob-all')
+const TemplateLinter = require('ember-template-lint')
+
+const linter = new TemplateLinter()
+
+const errors = glob.sync([
+  'app/**/*.hbs',
+  'tests/**/*.hbs'
+])
+  .map((filePath) => {
+    return linter.verify({
+      moduleId: filePath,
+      source: fs.readFileSync(filePath, {encoding: 'utf8'})
+    })
+  })
+  .reduce((a, b) => a.concat(b))
+
+errors.forEach((error) => {
+  console.log(`${error.rule}: ${error.message}`)
+  console.log(`(${error.moduleId}) @ L${error.line}:C${error.column}:\n`)
+  console.log('\t' + error.source.replace(/\n/g, '\n\t'))
+
+  if (error.fix) {
+    console.log('FIX:')
+    console.log(error.fix.text)
+  }
+
+  console.log('\n')
+})
+
+console.log(`===== ${errors.length} Template Linting Errors`)
+
+if (errors.length !== 0) {
+  process.exit(1)
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "doc": "doc",
     "test": "tests"
   },
+  "bin": {
+    "template-lint": "./cli/template-lint.js"
+  },
   "scripts": {
     "build": "ember build",
     "start": "ember server",


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Added** new `template-lint` executable for linting HTMLBars templates.
