### PR TITLE
Fix bug with eslint globals inconsistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,14 @@
 
 # 1.10.1
 
-* **Fixed** `lint-sass` to use `.sass-lint.yml` instead of `.sass-lint.json` as that is what in editor linting expects to be present.
+* **Fixed** `lint-sass` to use `.sass-lint.yml` instead of `.sass-lint.json` as that is what in editor linting expects
+to be present.
 
 
 # 1.10.0
 
-* **Added** new Node executables for linting: `lint-all-the-things`, `lint-docker`, `lint-htmlbars` (previously `template-lint`), `lint-javascript`, `lint-markdown`, and `lint-sass`.
+* **Added** new Node executables for linting: `lint-all-the-things`, `lint-docker`, `lint-htmlbars` (previously
+  `template-lint`), `lint-javascript`, `lint-markdown`, and `lint-sass`.
 
 
 # 1.9.0
@@ -44,12 +46,13 @@
 * Change CI browser example in *README.md* to match `ember-frost-core` usage
 
 # 1.5.0
-* **Added** a helper to stub out the ember-data store and make it easy to fake responses to calls to the store. 
-* **Updated** the dummy route and unit test for route to utilize the ember-data helper. 
+* **Added** a helper to stub out the ember-data store and make it easy to fake responses to calls to the store.
+* **Updated** the dummy route and unit test for route to utilize the ember-data helper.
 
 # 1.4.0
 
-* **Added** support to automatically add `ember-intl` dependencies to unit tests that specify `service:intl` in their dependencies
+* **Added** support to automatically add `ember-intl` dependencies to unit tests that specify `service:intl` in their
+dependencies
 * **Updated** lint rules and fixed new warnings
 
 
@@ -76,7 +79,10 @@
 
 # 1.2.1
 
-* **Improved** custom mocha reporter to show failures as they occur and only show passed tests when all pass (now sorting fastest to slowest to reduce a user from having to scroll as much in their terminal).
+* **Improved** custom mocha reporter to show failures as they occur and only show passed tests when all pass (now
+  sorting fastest to slowest to reduce a user from having to scroll as much in their terminal).
+
+<!--lint disable maximum-line-length-->
 
 When there are failures without stack traces it'll look like this:
 <img width="1205" alt="screen shot 2016-12-01 at 3 00 46 pm" src="https://cloud.githubusercontent.com/assets/422902/20816671/639871d8-b7d8-11e6-86e9-e85830e87a37.png">
@@ -87,6 +93,7 @@ When there are failures with stack traces it'll look like this:
 When all tests pass it'll look like this:
 <img width="1270" alt="screen shot 2016-12-01 at 2 06 57 pm" src="https://cloud.githubusercontent.com/assets/422902/20814645/71377978-b7cf-11e6-9b6d-01d682e448be.png">
 
+<!--lint enable maximum-line-length-->
 
 # 1.2.0
 
@@ -95,22 +102,29 @@ When all tests pass it'll look like this:
 
 # 1.1.2
 
-- **Fixed** generated test names to use `/` instead of `|` as the test name separator, grep-ing the interactive web app can link to unique tests.
+- **Fixed** generated test names to use `/` instead of `|` as the test name separator, grep-ing the interactive web
+app can link to unique tests.
 
 
 # 1.1.1
-* **Fixed** test descriptions to be consistent in the format of `Unit | Component | my-component` instead of `Unit: MyComponentComponent` so that `grep`-ing for your component name will actually find tests for your component now.
+* **Fixed** test descriptions to be consistent in the format of `Unit | Component | my-component` instead of
+`Unit: MyComponentComponent` so that `grep`-ing for your component name will actually find tests for your component
+now.
  * **Added** unit tests for the helpers themselves to make sure descriptions remain correct.
 
 # 1.1.0
-*  **Added** a `serializer` shortcut to the `describe-model` module which yields a `Unit | Serializer | model-name` description compared to the `Unit | Model | model-name` that the `model` shortcut yields.
+*  **Added** a `serializer` shortcut to the `describe-model` module which yields a
+`Unit | Serializer | model-name` description compared to the `Unit | Model | model-name` that the `model` shortcut
+yields.
 
 
 
 # 1.0.0
 ## Breaking Changes
- * **Removed** `registryHelper` functionality (it isn't as necessary/useful with the introduction of `ember-hook` to make things less brittle.
- * **Moved** remaining code to `test-support/helpers/ember-test-utils` so consumers can have it injected into `tests/helpers` instead of treating it like a normal addon which will have code injected into the main app code tree.
+ * **Removed** `registryHelper` functionality (it isn't as necessary/useful with the introduction of `ember-hook`
+ to make things less brittle.
+ * **Moved** remaining code to `test-support/helpers/ember-test-utils` so consumers can have it injected into
+ `tests/helpers` instead of treating it like a normal addon which will have code injected into the main app code tree.
 
 ## Non-breaking changes
  * **Added** helpers for `describeComponent` to make writing unit and integration tests easier

--- a/README.md
+++ b/README.md
@@ -301,7 +301,8 @@ describe(test.label, function () {
 
 ## Custom Mocha Reporter
 
-If you'd like to use the custom Mocha reporter provided by this addon then your `testem.js` file should look something like this:
+If you'd like to use the custom Mocha reporter provided by this addon then your `testem.js` file should look something
+like this:
 
 ```js
 var Reporter = require('ember-test-utils/reporter')
@@ -320,7 +321,8 @@ module.exports = {
 }
 ```
 
-> NOTE: This reporter will group test results into two sections: failed and passed. Each section is sorted from slowest test to fastest test so you can see which tests are causing your CI to come to a crawl.
+> NOTE: This reporter will group test results into two sections: failed and passed. Each section is sorted from slowest
+test to fastest test so you can see which tests are causing your CI to come to a crawl.
 
 ## Linting
 

--- a/cli/lint-htmlbars.js
+++ b/cli/lint-htmlbars.js
@@ -8,6 +8,7 @@
 
 const TemplateLinter = require('ember-template-lint')
 const fs = require('fs')
+const path = require('path')
 const glob = require('glob-all')
 
 const Linter = require('./linter')
@@ -33,7 +34,9 @@ const FILE_LOCATIONS = [
 const HtmlbarsLinter = function () {
   Linter.call(this, {
     configFileNames: CONFIG_FILE_NAMES,
-    defaultConfig: 'node_modules/ember-template-lint/lib/config/recommended.js',
+    defaultConfig: path.join(
+      process.cwd(), 'node_modules', 'ember-template-lint', 'lib', 'config', 'recommended.js'
+    ),
     fileLocations: FILE_LOCATIONS
   })
 }

--- a/cli/lint-javascript.js
+++ b/cli/lint-javascript.js
@@ -41,24 +41,6 @@ JavascriptLinter.prototype = Object.create(Linter.prototype)
 JavascriptLinter.prototype.constructor = JavascriptLinter
 
 /**
- * Get text color for severity
- * @param {Number} severity - sevrity
- * @returns {String} sevrity color
- */
-function getSeverityColor (severity) {
-  switch (severity) {
-    case 1:
-      return 'yellow'
-
-    case 2:
-      return 'red'
-
-    default:
-      return 'black'
-  }
-}
-
-/**
  * Get human friendly label for severity
  * @param {Number} severity - sevrity
  * @returns {String} sevrity label
@@ -82,6 +64,13 @@ function getSeverityLabel (severity) {
  */
 JavascriptLinter.prototype.lint = function () {
   const config = this.getConfig()
+
+  // .eslintrc expects globals to be an object but CLIEngine expects an array
+  // @see https://github.com/eslint/eslint/issues/7967
+  if (typeof config.globals === 'object' && !Array.isArray(config.globals)) {
+    config.globals = Object.keys(config.globals)
+  }
+
   const cli = new CLIEngine(config)
 
   const report = cli.executeOnFiles(this.fileLocations)

--- a/cli/linter.js
+++ b/cli/linter.js
@@ -28,6 +28,10 @@ Linter.prototype = {
 
     // If no configuration file was found use configuration from this addon
     if (!configFile) {
+      if (this.defaultConfig[0] === '/') {
+        return this.loadFile(this.defaultConfig)
+      }
+
       return this.loadFile(path.join(__dirname, '..', this.defaultConfig))
     }
 

--- a/tests/cli/lint-javascript-spec.js
+++ b/tests/cli/lint-javascript-spec.js
@@ -337,5 +337,43 @@ describe('lint-javascript', function () {
         })
       })
     })
+
+    describe('when config file is valid JSON and contains globals object', function () {
+      beforeEach(function () {
+        const originalFn = fs.readFileSync
+
+        sandbox.stub(fs, 'readFileSync', function (filePath) {
+          if (filePath.indexOf('.eslintrc') !== -1) {
+            return JSON.stringify({
+              globals: {
+                andThen: false
+              },
+              rules: {
+                'complexity': ['error', 2],
+                'no-console': ['warn']
+              }
+            })
+          }
+
+          return originalFn(...arguments)
+        })
+      })
+
+      describe('when no files to lint', function () {
+        beforeEach(function () {
+          const originalFn = CLIEngine.prototype.executeOnFiles
+
+          sandbox.stub(CLIEngine.prototype, 'executeOnFiles', function () {
+            return originalFn.call(this, [])
+          })
+        })
+
+        it('does not throw error', function () {
+          expect(function () {
+            linter.lint()
+          }).not.to.throw()
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** bug in Javascript linter around ESLint inconsistency with `globals` key. In a `.eslintrc` config it expects `globals` to be an object but when using the `CLIEngine` it expects an array.
