### PR TITLE
Fix bug when trying to reduce an empty array

### DIFF
--- a/cli/lint-htmlbars.js
+++ b/cli/lint-htmlbars.js
@@ -60,7 +60,7 @@ HtmlbarsLinter.prototype.lint = function () {
         source: fs.readFileSync(filePath, {encoding: 'utf8'})
       })
     })
-    .reduce((a, b) => a.concat(b))
+    .reduce((a, b) => a.concat(b), [])
 
   errors.forEach((error) => {
     console.log(`${error.rule}: ${error.message}`)


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Fixed** bug when trying to reduce an empty array without an initial value.
