### PR TITLE
Added strict mode for node compatibility

### DIFF
--- a/cli/linter.js
+++ b/cli/linter.js
@@ -1,3 +1,4 @@
+'use strict'
 const chalk = require('chalk')
 const fs = require('fs')
 const YAML = require('node-yaml')


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
**Added** the `'use strict'` directive to `linter.js`
