### PR TITLE
Add more helpers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
   fast_finish: true
   allow_failures:
   - env: EMBER_TRY_SCENARIO=ember-release
+  - node_js: 'stable'
 before_install:
 - npm config set spin false
 - npm install -g coveralls pr-bumper@^1.0.0

--- a/addon-test-support/setup-test.js
+++ b/addon-test-support/setup-test.js
@@ -115,3 +115,49 @@ export function controller (name, dependencies, options = {}) {
   }
   return module(`controller:${name}`, options)
 }
+
+/**
+ * A helper for formatting the describe text and calling setupTest with proper parameters for a service unit test
+ * @param {String} name - the name of the service
+ * @param {String[]} dependencies - the list of "needs" for this service
+ * @param {Object} options - any additional options to set (alongside unit: true)
+ * @returns {Test} a test config object
+ */
+export function service (name, dependencies, options = {}) {
+  if (dependencies) {
+    options.needs = dependencies
+  }
+  return module(`service:${name}`, options)
+}
+
+/**
+ * A helper for formatting the describe text and calling setupTest with proper parameters for an adapter unit test
+ * @param {String} name - the name of the adapter
+ * @param {String[]} dependencies - the list of "needs" for this adapter
+ * @param {Object} options - any additional options to set (alongside unit: true)
+ * @returns {Test} a test config object
+ */
+export function adapter (name, dependencies, options = {}) {
+  if (dependencies) {
+    options.needs = dependencies
+  }
+  return module(`adapter:${name}`, options)
+}
+
+/**
+ * A helper for formatting the describe text and calling setupTest with proper parameters for a helper unit test
+ * @param {String} name - the name of the helper
+ * @param {String[]} dependencies - the list of "needs" for this helper
+ * @param {Object} options - any additional options to set (alongside unit: true)
+ * @returns {Test} a test config object
+ */
+export function helper (name, dependencies, options = {}) {
+  if (dependencies) {
+    options.needs = dependencies
+  }
+  // defaultSubject assumes this is a instantiable object but helpers are not
+  options.subject = function (options, factory) {
+    return factory.compute
+  }
+  return module(`helper:${name}`, options)
+}

--- a/tests/cli/lint-javascript-spec.js
+++ b/tests/cli/lint-javascript-spec.js
@@ -171,11 +171,11 @@ describe('lint-javascript', function () {
         it('logs expected output', function () {
           expect(logOutput).to.eql([
             '\u001b[4mtests/cli/fixtures/error-1.js\u001b[24m',
-            '  \u001b[2m1:18\u001b[22m  \u001b[31merror\u001b[39m  Function \'anonymous\' ' +
+            '  \u001b[2m1:18\u001b[22m  \u001b[31merror\u001b[39m  Function ' +
               'has a complexity of 3  \u001b[2mcomplexity\u001b[22m',
             '',
             '\u001b[4mtests/cli/fixtures/error-2.js\u001b[24m',
-            '  \u001b[2m1:18\u001b[22m  \u001b[31merror\u001b[39m  Function \'anonymous\' ' +
+            '  \u001b[2m1:18\u001b[22m  \u001b[31merror\u001b[39m  Function ' +
               'has a complexity of 4  \u001b[2mcomplexity\u001b[22m',
             '',
             '\u001b[1m\u001b[37m\u001b[41m Javascript: 2 errors, 0 warnings \u001b[49m\u001b[39m\u001b[22m\n'
@@ -321,11 +321,11 @@ describe('lint-javascript', function () {
         it('logs expected output', function () {
           expect(logOutput).to.eql([
             '\u001b[4mtests/cli/fixtures/error-1.js\u001b[24m',
-            '  \u001b[2m1:18\u001b[22m  \u001b[31merror\u001b[39m  Function \'anonymous\' ' +
+            '  \u001b[2m1:18\u001b[22m  \u001b[31merror\u001b[39m  Function ' +
               'has a complexity of 3  \u001b[2mcomplexity\u001b[22m',
             '',
             '\u001b[4mtests/cli/fixtures/error-2.js\u001b[24m',
-            '  \u001b[2m1:18\u001b[22m  \u001b[31merror\u001b[39m  Function \'anonymous\' ' +
+            '  \u001b[2m1:18\u001b[22m  \u001b[31merror\u001b[39m  Function ' +
               'has a complexity of 4  \u001b[2mcomplexity\u001b[22m',
             '',
             '\u001b[1m\u001b[37m\u001b[41m Javascript: 2 errors, 0 warnings \u001b[49m\u001b[39m\u001b[22m\n'

--- a/tests/unit/setup-test-test.js
+++ b/tests/unit/setup-test-test.js
@@ -3,7 +3,17 @@
  */
 
 import {expect} from 'chai'
-import {controller, deps, model, module, route, serializer} from 'ember-test-utils/test-support/setup-test'
+import {
+  adapter,
+  controller,
+  deps,
+  helper,
+  model,
+  module,
+  route,
+  serializer,
+  service
+} from 'ember-test-utils/test-support/setup-test'
 import {afterEach, beforeEach, describe, it} from 'mocha'
 import sinon from 'sinon'
 
@@ -251,6 +261,180 @@ describe('setupTest()', function () {
           expect(deps.setupTest).to.have.been.calledWith('controller:my-bar', {
             needs: ['component:foo-bar', 'helper:baz'],
             unit: true
+          })
+        })
+      })
+    })
+  })
+
+  describe('service()', function () {
+    let test
+    describe('when just name is given', function () {
+      beforeEach(function () {
+        test = service('my-bar')
+      })
+
+      it('should create proper describe label', function () {
+        expect(test.label).to.equal('Unit / Service / my-bar /')
+      })
+
+      describe('when .setup() is called', function () {
+        beforeEach(function () {
+          test.setup()
+        })
+
+        it('should call setupTest() with proper args', function () {
+          expect(deps.setupTest).to.have.been.calledWith('service:my-bar', {unit: true})
+        })
+      })
+    })
+
+    describe('when dependencies are given', function () {
+      let needs
+      beforeEach(function () {
+        needs = ['component:foo-bar', 'helper:baz']
+        test = service('my-bar', needs)
+      })
+
+      it('should create proper describe label', function () {
+        expect(test.label).to.equal('Unit / Service / my-bar /')
+      })
+
+      describe('when .setup() is called', function () {
+        beforeEach(function () {
+          test.setup()
+        })
+
+        it('should call setupTest() with proper args', function () {
+          expect(deps.setupTest).to.have.been.calledWith('service:my-bar', {
+            needs: ['component:foo-bar', 'helper:baz'],
+            unit: true
+          })
+        })
+      })
+    })
+  })
+
+  describe('adapter()', function () {
+    let test
+    describe('when just name is given', function () {
+      beforeEach(function () {
+        test = adapter('my-bar')
+      })
+
+      it('should create proper describe label', function () {
+        expect(test.label).to.equal('Unit / Adapter / my-bar /')
+      })
+
+      describe('when .setup() is called', function () {
+        beforeEach(function () {
+          test.setup()
+        })
+
+        it('should call setupTest() with proper args', function () {
+          expect(deps.setupTest).to.have.been.calledWith('adapter:my-bar', {unit: true})
+        })
+      })
+    })
+
+    describe('when dependencies are given', function () {
+      let needs
+      beforeEach(function () {
+        needs = ['component:foo-bar', 'helper:baz']
+        test = adapter('my-bar', needs)
+      })
+
+      it('should create proper describe label', function () {
+        expect(test.label).to.equal('Unit / Adapter / my-bar /')
+      })
+
+      describe('when .setup() is called', function () {
+        beforeEach(function () {
+          test.setup()
+        })
+
+        it('should call setupTest() with proper args', function () {
+          expect(deps.setupTest).to.have.been.calledWith('adapter:my-bar', {
+            needs: ['component:foo-bar', 'helper:baz'],
+            unit: true
+          })
+        })
+      })
+    })
+  })
+
+  describe('helper()', function () {
+    let test
+    describe('when just name is given', function () {
+      beforeEach(function () {
+        test = helper('my-bar')
+      })
+
+      it('should create proper describe label', function () {
+        expect(test.label).to.equal('Unit / Helper / my-bar /')
+      })
+      describe('when .setup() is called', function () {
+        beforeEach(function () {
+          test.setup()
+        })
+
+        describe('should call setupTest with proper args', function () {
+          it('should pass the proper module name', function () {
+            expect(deps.setupTest.getCall(0).args[0]).to.equal('helper:my-bar')
+          })
+
+          it('should specify unit as true', function () {
+            expect(deps.setupTest.getCall(0).args[1].unit).to.equal(true)
+          })
+
+          it('should override subject to return the helper', function () {
+            const factory = {
+              compute: sandbox.spy()
+            }
+            expect(deps.setupTest.getCall(0).args[1].subject({}, factory)).to.equal(factory.compute)
+          })
+        })
+      })
+    })
+
+    describe('when dependencies are given', function () {
+      let needs
+      beforeEach(function () {
+        needs = ['component:foo-bar', 'helper:baz']
+        test = helper('my-bar', needs)
+      })
+
+      it('should create proper describe label', function () {
+        expect(test.label).to.equal('Unit / Helper / my-bar /')
+      })
+
+      describe('when .setup() is called', function () {
+        beforeEach(function () {
+          test.setup()
+        })
+
+        describe('should call setupTest with proper args', function () {
+          it('should pass the proper module name', function () {
+            expect(deps.setupTest.getCall(0).args[0]).to.equal('helper:my-bar')
+          })
+
+          it('should pass in dependencies', function () {
+            expect(deps.setupTest.getCall(0).args[1].needs).to.eql(['component:foo-bar', 'helper:baz'])
+          })
+
+          it('should specify unit as true', function () {
+            expect(deps.setupTest.getCall(0).args[1].unit).to.equal(true)
+          })
+
+          it('should specify subject', function () {
+            expect(deps.setupTest.getCall(0).args[1].subject).not.to.equal(undefined)
+          })
+
+          it('should override subject to return the helper', function () {
+            const factory = {
+              compute: sandbox.spy()
+            }
+            expect(deps.setupTest.getCall(0).args[1].subject({}, factory)).to.equal(factory.compute)
           })
         })
       })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG

* **Added** more test setup helpers to support other common modules that utilizes the factory (services, adapters, helpers)
