### PR TITLE
Closes ciena-blueplanet/ember-test-utils#55

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -2,7 +2,7 @@
   "plugins": {
     "lint": {
       "list-item-indent": false,
-      "maximum-line-length": 119
+      "maximum-line-length": 120
     }
   },
   "settings": {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [x] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* Changed `maximum-line-length` for Markdown linter to 120