### PR TITLE
Fix link in documenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ ember install ember-test-utils
 use `ember-cli-mocha` and `ember-mocha` as your testing framework. It provides shortcuts for working with:
 
  * [`setupComponentTest`](#setupcomponenttest)
- * [`setupComponent`](#setupcomponent)
+ * [`setupTest`](#setuptest)
 
 Provided test helpers:
 


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* Fix link in documentation

This is being released as a minor in order to properly publish https://github.com/ciena-blueplanet/ember-test-utils/pull/60 as a minor, which is currently misconfiguration issues.