### PR TITLE
Add ability to lint a single js or hbs file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /.sass-cache
 /connect.lock
 /coverage/*
+/coverage-addon/*
 /libpeerconnection.log
 npm-debug.log
 testem.log

--- a/cli/lint-htmlbars.js
+++ b/cli/lint-htmlbars.js
@@ -47,15 +47,17 @@ HtmlbarsLinter.prototype.constructor = HtmlbarsLinter
 
 /**
  * Lint template files
+ * @param {String} [filePath] - single path to a file to lint (if given)
  * @returns {Boolean} returns true if there are linting errors
  */
-HtmlbarsLinter.prototype.lint = function () {
+HtmlbarsLinter.prototype.lint = function (filePath) {
   const options = {
     config: this.getConfig()
   }
   const linter = new TemplateLinter(options)
 
-  const errors = glob.sync(this.fileLocations)
+  const locations = filePath ? [filePath] : this.fileLocations
+  const errors = glob.sync(locations)
     .map((filePath) => {
       return linter.verify({
         moduleId: filePath,
@@ -89,8 +91,12 @@ HtmlbarsLinter.prototype.lint = function () {
 
 // If file was called via CLI
 if (require.main === module) {
+  let filePath
+  if (process.argv.length === 3) {
+    filePath = process.argv[2]
+  }
   const linter = new HtmlbarsLinter()
-  linter.lint()
+  linter.lint(filePath)
 
 // If file was required by another Node module
 } else {

--- a/cli/lint-javascript.js
+++ b/cli/lint-javascript.js
@@ -10,6 +10,7 @@ const Linter = require('./linter')
  */
 const FILE_LOCATIONS = [
   'addon/**/*.js',
+  'addon-test-support/**/*.js',
   'app/**/*.js',
   'config/**/*.js',
   'mirage/**/*.js',
@@ -60,9 +61,10 @@ function getSeverityLabel (severity) {
 
 /**
  * Lint Javascript files
+ * @param {String} [filePath] - single path to a file to lint (if given)
  * @returns {Boolean} returns true if there are linting errors
  */
-JavascriptLinter.prototype.lint = function () {
+JavascriptLinter.prototype.lint = function (filePath) {
   const config = this.getConfig()
 
   // .eslintrc expects globals to be an object but CLIEngine expects an array
@@ -73,7 +75,8 @@ JavascriptLinter.prototype.lint = function () {
 
   const cli = new CLIEngine(config)
 
-  const report = cli.executeOnFiles(this.fileLocations)
+  const locations = filePath ? [filePath] : this.fileLocations
+  const report = cli.executeOnFiles(locations)
 
   report.results.forEach((result) => {
     if (result.messages.length === 0) {
@@ -103,8 +106,12 @@ JavascriptLinter.prototype.lint = function () {
 
 // If file was called via CLI
 if (require.main === module) {
+  let filePath
+  if (process.argv.length === 3) {
+    filePath = process.argv[2]
+  }
   const linter = new JavascriptLinter()
-  linter.lint()
+  linter.lint(filePath)
 
 // If file was required by another Node module
 } else {

--- a/config/coverage.js
+++ b/config/coverage.js
@@ -1,9 +1,0 @@
-module.exports = {
-  coverageEnvVar: 'COVERAGE',
-  coverageFolder: 'coverage',
-  useBabelInstrumenter: true,
-  excludes: [
-    '*/app/**/*',
-    '*/tests/**/*'
-  ]
-}

--- a/package.json
+++ b/package.json
@@ -21,13 +21,19 @@
     "start": "ember server",
     "test": "npm run lint && npm run test-addon && npm run test-cli",
     "test-addon": "EMBER_TRY_SCENARIO=${EMBER_TRY_SCENARIO:=default} && ember try:one $EMBER_TRY_SCENARIO --- COVERAGE=true ember test",
-    "test-cli": "istanbul cover _mocha -- --recursive tests/cli/"
+    "test-cli": "istanbul cover --dir coverage _mocha -- --recursive tests/cli/"
   },
   "repository": "git@github.com:ciena-blueplanet/ember-test-utils.git",
   "engines": {
-    "node": ">= 5.0.0"
+    "node": ">= 6.9.1"
   },
   "author": "Sophy Pal (https://github.com/sophypal)",
+  "contributors": [
+    "Adam Meadows (https://github.com/job13er)",
+    "Matt Dahl (https://github.com/sandersky)",
+    "Michael Carroll (https://github.com/juwara0)",
+    "Jeremy Brown (https://github.com/notmessenger)"
+  ],
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.5.0",
@@ -35,6 +41,7 @@
     "ember-cli": "~2.11.0",
     "ember-cli-app-version": "^2.0.1",
     "ember-cli-chai": "0.3.2",
+    "ember-cli-code-coverage": "^0.3.12",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.6",

--- a/tests/cli/lint-javascript-spec.js
+++ b/tests/cli/lint-javascript-spec.js
@@ -376,4 +376,68 @@ describe('lint-javascript', function () {
       })
     })
   })
+
+  describe('when linting a whole project', function () {
+    let fileLocations
+    beforeEach(function () {
+      const originalFn = CLIEngine.prototype.executeOnFiles
+
+      sandbox.stub(CLIEngine.prototype, 'executeOnFiles', function () {
+        return originalFn.call(this, [])
+      })
+
+      linter.lint()
+      fileLocations = CLIEngine.prototype.executeOnFiles.lastCall.args[0]
+    })
+
+    it('should lint files in addon directory', function () {
+      expect(fileLocations).to.include('addon/**/*.js')
+    })
+
+    it('should lint files in addon-test-support/ directory', function () {
+      expect(fileLocations).to.include('addon-test-support/**/*.js')
+    })
+
+    it('should lint files in app/ directory', function () {
+      expect(fileLocations).to.include('app/**/*.js')
+    })
+
+    it('should lint files in config/ directory', function () {
+      expect(fileLocations).to.include('config/**/*.js')
+    })
+
+    it('should lint files in mirage/ directory', function () {
+      expect(fileLocations).to.include('mirage/**/*.js')
+    })
+
+    it('should lint files in test-support/ directory', function () {
+      expect(fileLocations).to.include('test-support/**/*.js')
+    })
+
+    it('should lint files in tests/ directory', function () {
+      expect(fileLocations).to.include('tests/**/*.js')
+    })
+
+    it('should lint files at the root of the repo', function () {
+      expect(fileLocations).to.include('*.js')
+    })
+  })
+
+  describe('when linting a single file', function () {
+    let fileLocations
+    beforeEach(function () {
+      const originalFn = CLIEngine.prototype.executeOnFiles
+
+      sandbox.stub(CLIEngine.prototype, 'executeOnFiles', function () {
+        return originalFn.call(this, [])
+      })
+
+      linter.lint('foo/bar/baz.js')
+      fileLocations = CLIEngine.prototype.executeOnFiles.lastCall.args[0]
+    })
+
+    it('should only lint that one file', function () {
+      expect(fileLocations).to.eql(['foo/bar/baz.js'])
+    })
+  })
 })

--- a/tests/dummy/config/coverage.js
+++ b/tests/dummy/config/coverage.js
@@ -1,0 +1,15 @@
+module.exports = {
+  coverageEnvVar: 'COVERAGE',
+  coverageFolder: 'coverage-addon',
+  useBabelInstrumenter: true,
+  excludes: [
+    '*/app/**/*',
+    '**/dummy/**/*'
+  ],
+  reporters: [
+    'html',
+    'json-summary',
+    'lcov',
+    'text-summary'
+  ]
+}


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [x] #major# - incompatible API change

# CHANGELOG
 * **Update** `engine` in `package.json` to `>=6.9.1`. We've only been testing on `6.9.1` and `stable` anyway, but this makes it official that we don't suport `node@5` anymore. 
* **Addedd** the ability for `lint-javascript` and `lint-htmlbars` to accept a single file to lint on the command line. This is to enable the new `ember-cli-frost-blueprints` to lint the files it generates one at a time and get specific errors for only the file in question. 
