### PR TITLE
Add docs/ directory to markdown lint defaults

### DIFF
--- a/cli/lint-markdown.js
+++ b/cli/lint-markdown.js
@@ -23,6 +23,7 @@ const CONFIG_FILE_NAMES = [
 const FILE_LOCATIONS = [
   'addon/**/*.md',
   'app/**/*.md',
+  'docs/**/*.md',
   'tests/**/*.md',
   '*.md'
 ]

--- a/tests/cli/lint-markdown-spec.js
+++ b/tests/cli/lint-markdown-spec.js
@@ -52,6 +52,26 @@ describe('lint-markdown', function () {
     sandbox.restore()
   })
 
+  it('should default to include top-level markdown files', function () {
+    expect(linter.fileLocations).to.include('*.md')
+  })
+
+  it('should default to include doc markdown files', function () {
+    expect(linter.fileLocations).to.include('docs/**/*.md')
+  })
+
+  it('should default to include addon markdown files', function () {
+    expect(linter.fileLocations).to.include('addon/**/*.md')
+  })
+
+  it('should default to include app markdown files', function () {
+    expect(linter.fileLocations).to.include('app/**/*.md')
+  })
+
+  it('should default to include test markdown files', function () {
+    expect(linter.fileLocations).to.include('tests/**/*.md')
+  })
+
   describe('when no config file found', function () {
     beforeEach(function () {
       const files = Array.from(rootProjectFiles)


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
 * **Added** `docs/**/*.md` to the default file locations covered by `lint-markdown`
