### PR TITLE
Fix publishing of the build

### DIFF
--- a/.travis/maybe-bump-version.sh
+++ b/.travis/maybe-bump-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$EMBER_TRY_SCENARIO" != "default" ]
+if [ "$EMBER_TRY_SCENARIO" != "ember-default" ]
 then
   echo "Skipping version bump for EMBER_TRY_SCENARIO ${EMBER_TRY_SCENARIO}"
   exit 0


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [X] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Updated** the build scripts to publish under `ember-default`
Listing changes that were not picked up from previous PR: https://github.com/ciena-blueplanet/ember-test-utils/pull/85
* **Updated** to Ember CLI 2.12.3 and Ember 2.12.x
* **Updated** ember-try config matrix with Ember LTS 2.8
* **Updated** travis.yml build matrix to run Ember LTS 2.8 and default (Ember LTS 2.12) 