### PR TITLE
Remove included hook from index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,6 @@
 module.exports = {
   name: 'ember-test-utils',
 
-  included: function (app) {
-    this._super.included(app)
-  },
-
   treeForAddon (tree) {
     const environment = this.app.env
     const config = this.pkg['ember-test-utils'] || {}


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [X] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes: https://github.com/ciena-blueplanet/ember-test-utils/issues/94

# CHANGELOG
* **Removed** `included` hook from `index.js` since it was not being used to add additional functionality.