### PR TITLE
Update dependencies

### DIFF
--- a/.remarkignore
+++ b/.remarkignore
@@ -1,2 +1,3 @@
 warn-1.md
 warn-2.md
+CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ use `ember-cli-mocha` and `ember-mocha` as your testing framework. It provides s
 
 Provided test helpers:
 
- * [`mockComponent`](#mockcomponent) - creates a mock component to easily test the component dependency injection pattern
+ * [`mockComponent`](#mockcomponent) - creates a mock component to easily test the component dependency
+ injection pattern
  * [`stubService`](#stubservice) - allows you to stub a service
 
 ## `setupComponentTest`
@@ -569,7 +570,9 @@ describe(test.label, function () {
 
 ## Build Optimization
 
-Out of box having `ember-test-utils` in your project will make your vendor.js asset slightly larger, as of 2017-02-15 this increase in size is approximately 0.08 KB. If you want to keep this out of your build for certain environments you can add the following configuration to your `package.json`:
+Out of box having `ember-test-utils` in your project will make your vendor.js asset slightly larger, as of 2017-02-15
+ this increase in size is approximately 0.08 KB. If you want to keep this out of your build for certain environments
+ you can add the following configuration to your `package.json`:
 
 ```json
 {
@@ -679,7 +682,8 @@ and run
 npm run lint-js
 ```
 
-If you would like any Javascript files to be ignored during linting simply create a `.eslintignore` file in the root of your project and populate it with one
+If you would like any Javascript files to be ignored during linting simply create a `.eslintignore` file in the root
+ of your project and populate it with one
 [glob pattern](http://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories) per line.
 
 
@@ -707,7 +711,8 @@ and run
 npm run lint-md
 ```
 
-If you would like any Markdown files to be ignored during linting simply create a `.remarkignore` file in the root of your project and populate it with one
+If you would like any Markdown files to be ignored during linting simply create a `.remarkignore` file in the root
+ of your project and populate it with one
 [glob pattern](https://github.com/unifiedjs/unified-engine/blob/master/doc/ignore.md) per line.
 
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "broccoli-asset-rev": "^2.4.5",
     "chai-jquery": "^2.0.0",
     "ember-cli": "2.12.3",
-    "ember-cli-chai": "0.3.2",
+    "ember-cli-chai": "0.4.3",
     "ember-cli-code-coverage": "^0.3.12",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "devDependencies": {
     "bower": "^1.8.2",
     "broccoli-asset-rev": "^2.4.5",
-    "chai-jquery": "^2.0.0",
     "ember-cli": "2.12.3",
     "ember-cli-chai": "0.4.3",
     "ember-cli-code-coverage": "0.3.12",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "chalk": "^2.3.0",
     "dockerfile_lint": "^0.2.7",
-    "ember-cli-babel": "^5.1.5",
+    "ember-cli-babel": "^5.1.7",
     "ember-template-lint": "^0.8.12",
     "eslint": "^4.0.0",
     "eslint-config-frost-standard": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "0.3.12",
     "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-mocha": "0.13.2",
+    "ember-cli-mocha": "0.14.4",
     "ember-cli-shims": "^1.0.2",
     "ember-cli-uglify": "^1.2.0",
     "ember-computed-decorators": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-template-lint": "^0.8.12",
     "eslint": "^4.0.0",
-    "eslint-config-frost-standard": "^8.0.0",
+    "eslint-config-frost-standard": "^9.0.0",
     "glob-all": "^3.1.0",
     "node-yaml": "^3.1.1",
     "remark": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "dockerfile_lint": "^0.2.7",
     "ember-cli-babel": "^5.1.7",
     "ember-template-lint": "^0.8.12",
-    "eslint": "^4.0.0",
+    "eslint": "^4.11.0",
     "eslint-config-frost-standard": "^9.0.0",
     "glob-all": "^3.1.0",
     "node-yaml": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
-    "ember-sinon": "0.6.0",
+    "ember-sinon": "^0.7.0",
     "ember-source": "~2.12.0",
     "istanbul": "^0.4.5",
     "loader.js": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "glob-all": "^3.1.0",
     "node-yaml": "^3.1.1",
     "remark": "^6.2.0",
-    "remark-lint": "^6.0.1",
+    "remark-lint": "^5.4.0",
     "sass-lint": "^1.10.2"
   },
   "ember-addon": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "ember-computed-decorators": "0.3.0",
     "ember-data": "~2.12.0",
     "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "glob-all": "^3.1.0",
     "node-yaml": "^3.1.1",
     "remark": "^6.2.0",
-    "remark-lint": "^5.4.0",
+    "remark-lint": "^6.0.1",
     "sass-lint": "^1.10.2"
   },
   "ember-addon": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint": "^4.0.0",
     "eslint-config-frost-standard": "^8.0.0",
     "glob-all": "^3.1.0",
-    "node-yaml": "^3.0.3",
+    "node-yaml": "^3.1.1",
     "remark": "^6.2.0",
     "remark-lint": "^5.4.0",
     "sass-lint": "^1.10.2"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "chai-jquery": "^2.0.0",
     "ember-cli": "2.12.3",
     "ember-cli-chai": "0.4.3",
-    "ember-cli-code-coverage": "^0.3.12",
+    "ember-cli-code-coverage": "0.3.12",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "0.3.12",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ember-source": "~2.12.0",
     "istanbul": "^0.4.5",
     "loader.js": "^4.2.3",
-    "sinon-chai": "^2.8.0"
+    "sinon-chai": "^2.14.0"
   },
   "keywords": [
     "ember-addon"

--- a/tests/cli/lint-htmlbars-spec.js
+++ b/tests/cli/lint-htmlbars-spec.js
@@ -26,7 +26,7 @@ describe('lint-htmlbars', function () {
     sandbox = sinon.sandbox.create()
     sandbox.stub(linter, 'getConfig').returns({the: 'config'})
     sandbox.stub(linter, 'printLintSummary')
-    sandbox.stub(console, 'log', function (text) {
+    sandbox.stub(console, 'log').callsFake(function (text) {
       logOutput.push(text)
     })
 

--- a/tests/cli/lint-javascript-spec.js
+++ b/tests/cli/lint-javascript-spec.js
@@ -31,7 +31,7 @@ describe('lint-javascript', function () {
     logOutput = []
     sandbox = sinon.sandbox.create()
 
-    sandbox.stub(console, 'log', function (text) {
+    sandbox.stub(console, 'log').callsFake(function (text) {
       logOutput.push(text)
     })
   })
@@ -44,7 +44,7 @@ describe('lint-javascript', function () {
     beforeEach(function () {
       const files = Array.from(rootProjectFiles)
 
-      sandbox.stub(fs, 'readdirSync', function (directory) {
+      sandbox.stub(fs, 'readdirSync').callsFake(function (directory) {
         fs.readdirSync.restore() // Restore original method so sass-lint can use it
         return files
       })
@@ -66,7 +66,7 @@ describe('lint-javascript', function () {
       beforeEach(function () {
         const originalFn = fs.readFileSync
 
-        sandbox.stub(fs, 'readFileSync', function (filePath) {
+        sandbox.stub(fs, 'readFileSync').callsFake(function (filePath) {
           if (filePath.indexOf('.eslintrc.js') !== -1) {
             const exportsStr = JSON.stringify({
               rules: {
@@ -85,7 +85,7 @@ describe('lint-javascript', function () {
         beforeEach(function () {
           const originalFn = CLIEngine.prototype.executeOnFiles
 
-          sandbox.stub(CLIEngine.prototype, 'executeOnFiles', function () {
+          sandbox.stub(CLIEngine.prototype, 'executeOnFiles').callsFake(function () {
             return originalFn.call(this, [])
           })
         })
@@ -101,7 +101,7 @@ describe('lint-javascript', function () {
         beforeEach(function () {
           const originalFn = CLIEngine.prototype.executeOnFiles
 
-          sandbox.stub(CLIEngine.prototype, 'executeOnFiles', function () {
+          sandbox.stub(CLIEngine.prototype, 'executeOnFiles').callsFake(function () {
             return originalFn.call(this, [
               'tests/cli/fixtures/valid-*.js'
             ])
@@ -127,7 +127,7 @@ describe('lint-javascript', function () {
         beforeEach(function () {
           const originalFn = CLIEngine.prototype.executeOnFiles
 
-          sandbox.stub(CLIEngine.prototype, 'executeOnFiles', function () {
+          sandbox.stub(CLIEngine.prototype, 'executeOnFiles').callsFake(function () {
             return originalFn.call(this, [
               'tests/cli/fixtures/warn-*.js'
             ])
@@ -161,7 +161,7 @@ describe('lint-javascript', function () {
         beforeEach(function () {
           const originalFn = CLIEngine.prototype.executeOnFiles
 
-          sandbox.stub(CLIEngine.prototype, 'executeOnFiles', function () {
+          sandbox.stub(CLIEngine.prototype, 'executeOnFiles').callsFake(function () {
             return originalFn.call(this, [
               'tests/cli/fixtures/error-*.js'
             ])
@@ -195,7 +195,7 @@ describe('lint-javascript', function () {
       const files = Array.from(rootProjectFiles)
       files.push('.eslintrc.js')
 
-      sandbox.stub(fs, 'readdirSync', function (directory) {
+      sandbox.stub(fs, 'readdirSync').callsFake(function (directory) {
         fs.readdirSync.restore() // Restore original method so sass-lint can use it
         return files
       })
@@ -217,7 +217,7 @@ describe('lint-javascript', function () {
       beforeEach(function () {
         const originalFn = fs.readFileSync
 
-        sandbox.stub(fs, 'readFileSync', function (filePath) {
+        sandbox.stub(fs, 'readFileSync').callsFake(function (filePath) {
           if (filePath.indexOf('.eslintrc.js') !== -1) {
             const exportsStr = JSON.stringify({
               rules: {
@@ -236,7 +236,7 @@ describe('lint-javascript', function () {
         beforeEach(function () {
           const originalFn = CLIEngine.prototype.executeOnFiles
 
-          sandbox.stub(CLIEngine.prototype, 'executeOnFiles', function () {
+          sandbox.stub(CLIEngine.prototype, 'executeOnFiles').callsFake(function () {
             return originalFn.call(this, [])
           })
         })
@@ -252,7 +252,7 @@ describe('lint-javascript', function () {
         beforeEach(function () {
           const originalFn = CLIEngine.prototype.executeOnFiles
 
-          sandbox.stub(CLIEngine.prototype, 'executeOnFiles', function () {
+          sandbox.stub(CLIEngine.prototype, 'executeOnFiles').callsFake(function () {
             return originalFn.call(this, [
               'tests/cli/fixtures/valid-*.js'
             ])
@@ -278,7 +278,7 @@ describe('lint-javascript', function () {
         beforeEach(function () {
           const originalFn = CLIEngine.prototype.executeOnFiles
 
-          sandbox.stub(CLIEngine.prototype, 'executeOnFiles', function () {
+          sandbox.stub(CLIEngine.prototype, 'executeOnFiles').callsFake(function () {
             return originalFn.call(this, [
               'tests/cli/fixtures/warn-*.js'
             ])
@@ -312,7 +312,7 @@ describe('lint-javascript', function () {
         beforeEach(function () {
           const originalFn = CLIEngine.prototype.executeOnFiles
 
-          sandbox.stub(CLIEngine.prototype, 'executeOnFiles', function () {
+          sandbox.stub(CLIEngine.prototype, 'executeOnFiles').callsFake(function () {
             return originalFn.call(this, [
               'tests/cli/fixtures/error-*.js'
             ])
@@ -344,7 +344,7 @@ describe('lint-javascript', function () {
       beforeEach(function () {
         const originalFn = fs.readFileSync
 
-        sandbox.stub(fs, 'readFileSync', function (filePath) {
+        sandbox.stub(fs, 'readFileSync').callsFake(function (filePath) {
           if (filePath.indexOf('.eslintrc.js') !== -1) {
             const exportsStr = JSON.stringify({
               globals: {
@@ -366,7 +366,7 @@ describe('lint-javascript', function () {
         beforeEach(function () {
           const originalFn = CLIEngine.prototype.executeOnFiles
 
-          sandbox.stub(CLIEngine.prototype, 'executeOnFiles', function () {
+          sandbox.stub(CLIEngine.prototype, 'executeOnFiles').callsFake(function () {
             return originalFn.call(this, [])
           })
         })
@@ -385,7 +385,7 @@ describe('lint-javascript', function () {
     beforeEach(function () {
       const originalFn = CLIEngine.prototype.executeOnFiles
 
-      sandbox.stub(CLIEngine.prototype, 'executeOnFiles', function () {
+      sandbox.stub(CLIEngine.prototype, 'executeOnFiles').callsFake(function () {
         return originalFn.call(this, [])
       })
 
@@ -431,7 +431,7 @@ describe('lint-javascript', function () {
     beforeEach(function () {
       const originalFn = CLIEngine.prototype.executeOnFiles
 
-      sandbox.stub(CLIEngine.prototype, 'executeOnFiles', function () {
+      sandbox.stub(CLIEngine.prototype, 'executeOnFiles').callsFake(function () {
         return originalFn.call(this, [])
       })
 

--- a/tests/cli/lint-markdown-spec.js
+++ b/tests/cli/lint-markdown-spec.js
@@ -43,7 +43,7 @@ describe('lint-markdown', function () {
     linter = new MarkdownLinter()
     logOutput = []
     sandbox = sinon.sandbox.create()
-    sandbox.stub(console, 'log', function (text) {
+    sandbox.stub(console, 'log').callsFake(function (text) {
       logOutput.push(text)
     })
   })
@@ -76,7 +76,7 @@ describe('lint-markdown', function () {
     beforeEach(function () {
       const files = Array.from(rootProjectFiles)
 
-      sandbox.stub(fs, 'readdirSync', function (directory) {
+      sandbox.stub(fs, 'readdirSync').callsFake(function (directory) {
         fs.readdirSync.restore() // Restore original method so sass-lint can use it
         return files
       })
@@ -98,7 +98,7 @@ describe('lint-markdown', function () {
       beforeEach(function () {
         const originalFn = fs.readFileSync
 
-        sandbox.stub(fs, 'readFileSync', function (filePath) {
+        sandbox.stub(fs, 'readFileSync').callsFake(function (filePath) {
           if (filePath.indexOf('.remarkrc') !== -1) {
             return JSON.stringify({
               plugins: {
@@ -176,7 +176,7 @@ describe('lint-markdown', function () {
       const files = Array.from(rootProjectFiles)
       files.push('.remarkrc')
 
-      sandbox.stub(fs, 'readdirSync', function (directory) {
+      sandbox.stub(fs, 'readdirSync').callsFake(function (directory) {
         fs.readdirSync.restore() // Restore original method so sass-lint can use it
         return files
       })
@@ -198,7 +198,7 @@ describe('lint-markdown', function () {
       beforeEach(function () {
         const originalFn = fs.readFileSync
 
-        sandbox.stub(fs, 'readFileSync', function (filePath) {
+        sandbox.stub(fs, 'readFileSync').callsFake(function (filePath) {
           if (filePath.indexOf('.remarkrc') !== -1) {
             return JSON.stringify({
               plugins: {
@@ -278,7 +278,7 @@ describe('lint-markdown', function () {
       const files = Array.from(rootProjectFiles)
       files.push('.remarkignore')
 
-      sandbox.stub(fs, 'readdirSync', function (directory) {
+      sandbox.stub(fs, 'readdirSync').callsFake(function (directory) {
         fs.readdirSync.restore() // Restore original method so sass-lint can use it
         return files
       })

--- a/tests/cli/lint-sass-spec.js
+++ b/tests/cli/lint-sass-spec.js
@@ -49,7 +49,7 @@ describe('lint-sass', function () {
     linter = new SassLinter()
     logOutput = []
     sandbox = sinon.sandbox.create()
-    sandbox.stub(console, 'log', function (text) {
+    sandbox.stub(console, 'log').callsFake(function (text) {
       logOutput.push(text)
     })
   })
@@ -62,7 +62,7 @@ describe('lint-sass', function () {
     beforeEach(function () {
       const files = Array.from(rootProjectFiles)
 
-      sandbox.stub(fs, 'readdirSync', function (directory) {
+      sandbox.stub(fs, 'readdirSync').callsFake(function (directory) {
         fs.readdirSync.restore() // Restore original method so sass-lint can use it
         return files
       })
@@ -84,7 +84,7 @@ describe('lint-sass', function () {
       beforeEach(function () {
         const originalFn = fs.readFileSync
 
-        sandbox.stub(fs, 'readFileSync', function (filePath) {
+        sandbox.stub(fs, 'readFileSync').callsFake(function (filePath) {
           if (filePath.indexOf('.sass-lint.yml') !== -1) {
             return JSON.stringify({
               files: {
@@ -204,7 +204,7 @@ describe('lint-sass', function () {
       const files = Array.from(rootProjectFiles)
       files.push('.sass-lint.yml')
 
-      sandbox.stub(fs, 'readdirSync', function (directory) {
+      sandbox.stub(fs, 'readdirSync').callsFake(function (directory) {
         fs.readdirSync.restore() // Restore original method so sass-lint can use it
         return files
       })
@@ -226,7 +226,7 @@ describe('lint-sass', function () {
       beforeEach(function () {
         const originalFn = fs.readFileSync
 
-        sandbox.stub(fs, 'readFileSync', function (filePath) {
+        sandbox.stub(fs, 'readFileSync').callsFake(function (filePath) {
           if (filePath.indexOf('.sass-lint.yml') !== -1) {
             return JSON.stringify({
               files: {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [X] #major# - incompatible API change

Closes: https://github.com/ciena-blueplanet/ember-test-utils/issues/100

# CHANGELOG
* **Updated** to version `^5.1.7` of `ember-cli-babel`
* **Removed** unused `ember-disable-proxy-controllers package` package
* **Updated** to version `^3.1.1` of `node-yaml`
* **Updated** to version `^2.14.0` of `sinon-chai`
* **Updated** to version `0.14.4` of `ember-cli-mocha`
* **Updated** to version `0.4.3` of `ember-cli-chai`
* **Updated** to version `^0.7.0` of `ember-sinon`
* **Updated** by pinning to version `0.3.12` of `ember-cli-code-coverage`
* **Updated** to version `^9.0.0` of `eslint-config-frost-standard`
* **Updated** stub methods to use new `callsFake()` since old method has been deprecated
* **Updated** linting to ignore the `CHANGELOG.md` file
* **Removed** unused `chai-query` package
* **Updated** to version `^4.11.0` of `eslint`
