### PR TITLE
Added ability to use --fix with lint-all-the-things

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,4 +2,4 @@ bower_components/**/*
 dist/**/*
 node_modules/**/*
 tmp/**/*
-tests/cli/fixtures/*
+tests/cli/fixtures/fixable-error-1.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ bower_components/**/*
 dist/**/*
 node_modules/**/*
 tmp/**/*
+tests/cli/fixtures/*

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 npm-debug.log*
 testem.log
 coverage.json
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -634,6 +634,16 @@ and run
 npm run lint-all-the-things
 ```
 
+Many eslint errors and warnings can be automatically fixed using the `--fix` command line argument. For example,
+
+```bash
+./node_modules/.bin/lint-all-the-things --fix
+```
+
+```bash
+npm run lint-all-the-things -- --fix
+```
+
 ### Dockerfile
 
 If you want to lint your template files you can simply run:

--- a/cli/lint-javascript.js
+++ b/cli/lint-javascript.js
@@ -62,15 +62,21 @@ function getSeverityLabel (severity) {
 /**
  * Lint Javascript files
  * @param {String} [filePath] - single path to a file to lint (if given)
+ * @params {String[]} [specificArgs] - command line arguments to use instead of process args
  * @returns {Boolean} returns true if there are linting errors
  */
-JavascriptLinter.prototype.lint = function (filePath) {
+JavascriptLinter.prototype.lint = function (filePath, specificArgs) {
   const config = this.getConfig()
+  const args = specificArgs || process.argv
 
   // .eslintrc expects globals to be an object but CLIEngine expects an array
   // @see https://github.com/eslint/eslint/issues/7967
   if (typeof config.globals === 'object' && !Array.isArray(config.globals)) {
     config.globals = Object.keys(config.globals)
+  }
+
+  if (args.includes('--fix')) {
+    config.fix = true
   }
 
   const cli = new CLIEngine(config)
@@ -95,6 +101,10 @@ JavascriptLinter.prototype.lint = function (filePath) {
   })
 
   this.printLintSummary('Javascript', report.errorCount, report.warningCount)
+
+  if (config.fix) {
+    CLIEngine.outputFixes(report)
+  }
 
   // If file was called via CLI and there are errors exit process with failed status
   if (require.main === module && report.errorCount !== 0) {

--- a/cli/lint-javascript.js
+++ b/cli/lint-javascript.js
@@ -79,6 +79,11 @@ JavascriptLinter.prototype.lint = function (filePath, specificArgs) {
     config.fix = true
   }
 
+  if (args.includes('--no-ignore')) {
+    // This allows us to test with fixtures that would normally fail linting and are thus in the .eslintignore file
+    config.ignore = false
+  }
+
   const cli = new CLIEngine(config)
 
   const locations = filePath ? [filePath] : this.fileLocations

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "Adam Meadows (https://github.com/job13er)",
     "Matt Dahl (https://github.com/sandersky)",
     "Michael Carroll (https://github.com/juwara0)",
-    "Jeremy Brown (https://github.com/notmessenger)"
+    "Jeremy Brown (https://github.com/notmessenger)",
+    "Phillip Plummer (https://github.com/theotherdude"
   ],
   "license": "MIT",
   "devDependencies": {

--- a/reporter.js
+++ b/reporter.js
@@ -72,12 +72,7 @@ function testWriter (test, verbose) {
     }
 
     if (result.error) {
-      const e = result.error
-      this.out.write('\n\tError: ' + e.message + '\n')
-
-      if (e.stack) {
-        this.out.write('\n\t\t' + e.stack.toString().replace(/\n/g, '\n\t\t') + '\n')
-      }
+      writeIndividualError(result.error)
     }
   }
 }
@@ -111,6 +106,18 @@ function writeSummary (humanReadableDuration) {
     'ran ' + total + ' tests in ' + humanReadableDuration + ' [' + passed +
     ' passed / ' + failed + ' failed / ' + pending + ' pending]\n\n'
   )
+}
+
+/**
+ * Write out error in individual test result
+ * @param {Object} error - the error to write
+ */
+function writeIndividualError (error) {
+  this.out.write('\n\tError: ' + error.message + '\n')
+
+  if (error.stack) {
+    this.out.write('\n\t\t' + error.stack.toString().replace(/\n/g, '\n\t\t') + '\n')
+  }
 }
 
 function Reporter (silent, out) {

--- a/tests/cli/fixtures/fixable-error-1.js
+++ b/tests/cli/fixtures/fixable-error-1.js
@@ -1,0 +1,4 @@
+module.exports = function badFunc () {
+  var x = 10
+  return x
+}

--- a/tests/cli/lint-javascript-spec.js
+++ b/tests/cli/lint-javascript-spec.js
@@ -467,7 +467,7 @@ describe('lint-javascript', function () {
         return originalFn(...arguments)
       })
       sandbox.stub(CLIEngine, 'outputFixes')
-      result = linter.lint('tests/cli/fixtures/fixable-error-1.js')
+      result = linter.lint('tests/cli/fixtures/fixable-error-1.js', ['--no-ignore'])
     })
 
     it('should not call CLIEngine.outputFixes', function () {
@@ -485,7 +485,7 @@ describe('lint-javascript', function () {
     describe('when specifying "--fix" argument', function () {
       beforeEach(function () {
         logOutput = []
-        result = linter.lint('tests/cli/fixtures/fixable-error-1.js', ['--fix'])
+        result = linter.lint('tests/cli/fixtures/fixable-error-1.js', ['--fix', '--no-ignore'])
       })
 
       it('should call CLIEngine.outputFixes', function () {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #none# - documentation fixes and/or test additions
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Added** ability to specify `--fix` with lint-all-the-things to automatically apply eslint fixes
