### PR TITLE
Remove ember-cli-mocha useLintTree configuration option

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,9 +6,6 @@ module.exports = function (defaults) {
     babel: {
       optional: ['es7.decorators']
     },
-    'ember-cli-mocha': {
-      useLintTree: false
-    },
     sassOptions: {
       includePaths: [
         'node_modules/ember-frost-css-core/scss',


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [x] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Based on the conversations in https://github.com/ember-cli/ember-cli-mocha/issues/105 and https://github.com/ember-cli/ember-cli-eslint/issues/7 as well as this change https://github.com/ember-cli/ember-cli-qunit/commit/425a26eb60fabe919a161f71701dd74046d26c5b#diff-04c6e90faac2675aa89e2176d2eec7d8 the use of this configuration option was for the transition state between `JSHint` and `ESLint` and since that conversion has occurred in the version of Ember CLI we are using this option is no longer needed.

# CHANGELOG
* Remove `ember-cli-mocha` `useLintTree` configuration option